### PR TITLE
Add Diff support

### DIFF
--- a/plugins/module_utils/panos.py
+++ b/plugins/module_utils/panos.py
@@ -50,6 +50,7 @@ except ImportError:
 def _vstr(val):
     return '{0}.{1}.{2}'.format(*val)
 
+
 def eltostr(obj):
     try:
         # Try pretty print first if pandevice supports it
@@ -326,7 +327,9 @@ class ConnectionHelper(object):
             for item in listing:
                 if item.uid != obj.uid:
                     continue
-                diff = dict( before=eltostr(item) )
+                diff = dict(
+                    before=eltostr(item)
+                )
                 obj_child_types = [x.__class__ for x in obj.children]
                 other_children = []
                 for x in item.children:
@@ -382,7 +385,9 @@ class ConnectionHelper(object):
                     changed = True
 
                 if changed:
-                    diff = dict(before = eltostr(item))
+                    diff = dict(
+                        before=eltostr(item)
+                    )
                     setattr(item, enabled_disabled_param, not val)
                     diff['after'] = eltostr(item)
                     if not module.check_mode:

--- a/plugins/modules/panos_address_group.py
+++ b/plugins/modules/panos_address_group.py
@@ -163,14 +163,14 @@ def main():
     parent.add(obj)
 
     # Apply the state.
-    changed = helper.apply_state(obj, listing, module)
+    changed, diff = helper.apply_state(obj, listing, module)
 
     # Commit.
     if commit and changed:
         helper.commit(module)
 
     # Done.
-    module.exit_json(changed=changed)
+    module.exit_json(changed=changed, diff=diff)
 
 
 if __name__ == '__main__':

--- a/plugins/modules/panos_address_object.py
+++ b/plugins/modules/panos_address_object.py
@@ -168,14 +168,14 @@ def main():
     parent.add(obj)
 
     # Apply the state.
-    changed = helper.apply_state(obj, listing, module)
+    changed, diff = helper.apply_state(obj, listing, module)
 
     # Commit.
     if commit and changed:
         helper.commit(module)
 
     # Done.
-    module.exit_json(changed=changed)
+    module.exit_json(changed=changed, diff=diff)
 
 
 if __name__ == '__main__':

--- a/plugins/modules/panos_bgp.py
+++ b/plugins/modules/panos_bgp.py
@@ -271,12 +271,12 @@ def main():
     parent.add(bgp)
 
     # Apply the state.
-    changed = helper.apply_state(bgp, listing, module, 'enable')
+    changed, diff = helper.apply_state(bgp, listing, module, 'enable')
 
     if commit and changed:
         helper.commit(module)
 
-    module.exit_json(msg='BGP configuration successful.', changed=changed)
+    module.exit_json(msg='BGP configuration successful.', changed=changed, diff=diff)
 
 
 if __name__ == '__main__':

--- a/plugins/modules/panos_bgp_aggregate.py
+++ b/plugins/modules/panos_bgp_aggregate.py
@@ -290,13 +290,13 @@ def main():
     bgp.add(obj)
 
     # Apply the desired state.
-    changed = helper.apply_state(obj, listing, module)
+    changed, diff = helper.apply_state(obj, listing, module)
 
     # Optional: commit.
     if changed and commit:
         helper.commit(module)
 
-    module.exit_json(changed=changed, msg='done')
+    module.exit_json(changed=changed, diff=diff, msg='done')
 
 
 if __name__ == '__main__':

--- a/plugins/modules/panos_bgp_auth.py
+++ b/plugins/modules/panos_bgp_auth.py
@@ -169,12 +169,12 @@ def main():
     obj = BgpAuthProfile(**spec)
     parent.add(obj)
 
-    changed = helper.apply_state(obj, listing, module)
+    changed, diff = helper.apply_state(obj, listing, module)
 
     if commit and changed:
         helper.commit(module)
 
-    module.exit_json(changed=changed, msg='done')
+    module.exit_json(changed=changed, diff=diff, msg='done')
 
 
 if __name__ == '__main__':

--- a/plugins/modules/panos_bgp_conditional_advertisement.py
+++ b/plugins/modules/panos_bgp_conditional_advertisement.py
@@ -193,11 +193,11 @@ def main():
             filter_obj = pickle.loads(b64decode(val))
             obj.add(filter_obj)
 
-    changed = helper.apply_state(obj, listing, module)
+    changed, diff = helper.apply_state(obj, listing, module)
     if changed and module.params['commit']:
         helper.commit(module)
 
-    module.exit_json(changed=changed, msg='done')
+    module.exit_json(changed=changed, diff=diff, msg='done')
 
 
 if __name__ == '__main__':

--- a/plugins/modules/panos_bgp_dampening.py
+++ b/plugins/modules/panos_bgp_dampening.py
@@ -187,13 +187,13 @@ def main():
     bgp.add(obj)
 
     # Apply the requested state.
-    changed = helper.apply_state(obj, listing, module)
+    changed, diff = helper.apply_state(obj, listing, module)
 
     # Optional commit.
     if changed and module.params['commit']:
         helper.commit(module)
 
-    module.exit_json(changed=changed, msg='done')
+    module.exit_json(changed=changed, diff=diff, msg='done')
 
 
 if __name__ == '__main__':

--- a/plugins/modules/panos_bgp_peer.py
+++ b/plugins/modules/panos_bgp_peer.py
@@ -363,12 +363,12 @@ def main():
     obj = BgpPeer(**spec)
     group.add(obj)
 
-    changed = helper.apply_state(obj, listing, module)
+    changed, diff = helper.apply_state(obj, listing, module)
 
     if changed and module.params['commit']:
         helper.commit(module)
 
-    module.exit_json(changed=changed, msg='done')
+    module.exit_json(changed=changed, diff=diff, msg='done')
 
 
 if __name__ == '__main__':

--- a/plugins/modules/panos_bgp_peer_group.py
+++ b/plugins/modules/panos_bgp_peer_group.py
@@ -207,13 +207,13 @@ def main():
     bgp.add(obj)
 
     # Apply the state.
-    changed = helper.apply_state(obj, listing, module)
+    changed, diff = helper.apply_state(obj, listing, module)
 
     # Optional commit.
     if changed and module.params['commit']:
         helper.commit(module)
 
-    module.exit_json(changed=changed, msg='done')
+    module.exit_json(changed=changed, diff=diff, msg='done')
 
 
 if __name__ == '__main__':

--- a/plugins/modules/panos_bgp_policy_filter.py
+++ b/plugins/modules/panos_bgp_policy_filter.py
@@ -323,11 +323,11 @@ def main():
         panos_obj = b64encode(pickle.dumps(obj, protocol=pickle.HIGHEST_PROTOCOL))
         module.exit_json(msg='returning serialized object', panos_obj=panos_obj)
 
-    changed = helper.apply_state(obj, listing, module)
+    changed, diff = helper.apply_state(obj, listing, module)
     if changed and module.params['commit']:
         helper.commit(module)
 
-    module.exit_json(changed=changed, msg='done')
+    module.exit_json(changed=changed, diff=diff, msg='done')
 
 
 if __name__ == '__main__':

--- a/plugins/modules/panos_bgp_policy_rule.py
+++ b/plugins/modules/panos_bgp_policy_rule.py
@@ -417,13 +417,13 @@ def main():
     bgp.add(obj)
 
     # Apply the state.
-    changed = helper.apply_state(obj, listing, module)
+    changed, diff = helper.apply_state(obj, listing, module)
 
     # Optional commit.
     if changed and module.params['commit']:
         helper.commit(module)
 
-    module.exit_json(changed=changed, msg='done')
+    module.exit_json(changed=changed, diff=diff, msg='done')
 
 
 if __name__ == '__main__':

--- a/plugins/modules/panos_bgp_redistribute.py
+++ b/plugins/modules/panos_bgp_redistribute.py
@@ -233,12 +233,12 @@ def main():
     obj = BgpRedistributionRule(**spec)
     bgp.add(obj)
 
-    changed = helper.apply_state(obj, listing, module)
+    changed, diff = helper.apply_state(obj, listing, module)
 
     if changed and module.params['commit']:
         helper.commit(module)
 
-    module.exit_json(changed=changed, msg='done')
+    module.exit_json(changed=changed, diff=diff, msg='done')
 
 
 if __name__ == '__main__':

--- a/plugins/modules/panos_email_profile.py
+++ b/plugins/modules/panos_email_profile.py
@@ -191,8 +191,8 @@ def main():
     obj = EmailServerProfile(**spec)
     parent.add(obj)
 
-    changed = helper.apply_state(obj, listing, module)
-    module.exit_json(changed=changed, msg='Done')
+    changed, diff = helper.apply_state(obj, listing, module)
+    module.exit_json(changed=changed, diff=diff, msg='Done')
 
 
 if __name__ == '__main__':

--- a/plugins/modules/panos_email_server.py
+++ b/plugins/modules/panos_email_server.py
@@ -141,8 +141,8 @@ def main():
     obj = EmailServer(**spec)
     sp.add(obj)
 
-    changed = helper.apply_state(obj, listing, module)
-    module.exit_json(changed=changed, msg='Done')
+    changed, diff = helper.apply_state(obj, listing, module)
+    module.exit_json(changed=changed, diff=diff, msg='Done')
 
 
 if __name__ == '__main__':

--- a/plugins/modules/panos_gre_tunnel.py
+++ b/plugins/modules/panos_gre_tunnel.py
@@ -188,10 +188,10 @@ def main():
     parent.add(obj)
 
     # Apply the state.
-    changed = helper.apply_state(obj, listing, module)
+    changed, diff = helper.apply_state(obj, listing, module)
 
     # Done.
-    module.exit_json(changed=changed)
+    module.exit_json(changed=changed, diff=diff)
 
 
 if __name__ == '__main__':

--- a/plugins/modules/panos_ha.py
+++ b/plugins/modules/panos_ha.py
@@ -444,12 +444,12 @@ def main():
     listing[0].session_setup = obj.session_setup
 
     # Apply the state.
-    changed = helper.apply_state(obj, listing, module)
+    changed, diff = helper.apply_state(obj, listing, module)
 
     if commit and changed:
         helper.commit(module)
 
-    module.exit_json(msg='Done', changed=changed)
+    module.exit_json(msg='Done', changed=changed, diff=diff)
 
 
 if __name__ == '__main__':

--- a/plugins/modules/panos_http_profile.py
+++ b/plugins/modules/panos_http_profile.py
@@ -327,8 +327,8 @@ def main():
     obj = HttpServerProfile(**spec)
     parent.add(obj)
 
-    changed = helper.apply_state(obj, listing, module)
-    module.exit_json(changed=changed, msg='Done')
+    changed, diff = helper.apply_state(obj, listing, module)
+    module.exit_json(changed=changed, diff=diff, msg='Done')
 
 
 if __name__ == '__main__':

--- a/plugins/modules/panos_http_profile_header.py
+++ b/plugins/modules/panos_http_profile_header.py
@@ -172,8 +172,8 @@ def main():
     obj = cls(**spec)
     sp.add(obj)
 
-    changed = helper.apply_state(obj, listing, module)
-    module.exit_json(changed=changed, msg='Done')
+    changed, diff = helper.apply_state(obj, listing, module)
+    module.exit_json(changed=changed, diff=diff, msg='Done')
 
 
 if __name__ == '__main__':

--- a/plugins/modules/panos_http_profile_param.py
+++ b/plugins/modules/panos_http_profile_param.py
@@ -172,8 +172,8 @@ def main():
     obj = cls(**spec)
     sp.add(obj)
 
-    changed = helper.apply_state(obj, listing, module)
-    module.exit_json(changed=changed, msg='Done')
+    changed, diff = helper.apply_state(obj, listing, module)
+    module.exit_json(changed=changed, diff=diff, msg='Done')
 
 
 if __name__ == '__main__':

--- a/plugins/modules/panos_http_server.py
+++ b/plugins/modules/panos_http_server.py
@@ -171,8 +171,8 @@ def main():
     obj = HttpServer(**spec)
     sp.add(obj)
 
-    changed = helper.apply_state(obj, listing, module)
-    module.exit_json(changed=changed, msg='Done')
+    changed, diff = helper.apply_state(obj, listing, module)
+    module.exit_json(changed=changed, diff=diff, msg='Done')
 
 
 if __name__ == '__main__':

--- a/plugins/modules/panos_ike_crypto_profile.py
+++ b/plugins/modules/panos_ike_crypto_profile.py
@@ -196,14 +196,14 @@ def main():
     parent.add(obj)
 
     # Apply the state.
-    changed = helper.apply_state(obj, listing, module)
+    changed, diff = helper.apply_state(obj, listing, module)
 
     # Commit.
     if commit and changed:
         helper.commit(module)
 
     # Done.
-    module.exit_json(changed=changed)
+    module.exit_json(changed=changed, diff=diff)
 
 
 if __name__ == '__main__':

--- a/plugins/modules/panos_ike_gateway.py
+++ b/plugins/modules/panos_ike_gateway.py
@@ -292,14 +292,14 @@ def main():
     parent.add(obj)
 
     # Apply the state.
-    changed = helper.apply_state(obj, listing, module)
+    changed, diff = helper.apply_state(obj, listing, module)
 
     # Commit.
     if commit and changed:
         helper.commit(module)
 
     # Done.
-    module.exit_json(changed=changed)
+    module.exit_json(changed=changed, diff=diff)
 
 
 if __name__ == '__main__':

--- a/plugins/modules/panos_interface.py
+++ b/plugins/modules/panos_interface.py
@@ -350,7 +350,9 @@ def main():
         for item in interfaces:
             if item.name != eth.name:
                 continue
-            diff = dict( before=eltostr(item) )
+            diff = dict(
+                before=eltostr(item)
+            )
             # Interfaces have children, so don't compare them.
             if not item.equal(eth, compare_children=False):
                 changed = True
@@ -365,8 +367,8 @@ def main():
         else:
             changed = True
             diff = dict(
-                before = "",
-                after = eltostr(eth)
+                before="",
+                after=eltostr(eth)
             )
             if not module.check_mode:
                 try:
@@ -396,8 +398,8 @@ def main():
         if eth.name in [x.name for x in interfaces]:
             changed = True
             diff = dict(
-                before = eltostr(eth),
-                after = ""
+                before=eltostr(eth),
+                after=""
             )
             if not module.check_mode:
                 try:

--- a/plugins/modules/panos_ipsec_ipv4_proxyid.py
+++ b/plugins/modules/panos_ipsec_ipv4_proxyid.py
@@ -199,14 +199,14 @@ def main():
     tunnel.add(obj)
 
     # Apply the state.
-    changed = helper.apply_state(obj, listing, module)
+    changed, diff = helper.apply_state(obj, listing, module)
 
     # Commit.
     if commit and changed:
         helper.commit(module)
 
     # Done.
-    module.exit_json(changed=changed)
+    module.exit_json(changed=changed, diff=diff)
 
 
 if __name__ == '__main__':

--- a/plugins/modules/panos_ipsec_profile.py
+++ b/plugins/modules/panos_ipsec_profile.py
@@ -234,14 +234,14 @@ def main():
     parent.add(obj)
 
     # Apply the state.
-    changed = helper.apply_state(obj, listing, module)
+    changed, diff = helper.apply_state(obj, listing, module)
 
     # Commit.
     if commit and changed:
         helper.commit(module)
 
     # Done.
-    module.exit_json(changed=changed)
+    module.exit_json(changed=changed, diff=diff)
 
 
 if __name__ == '__main__':

--- a/plugins/modules/panos_ipsec_tunnel.py
+++ b/plugins/modules/panos_ipsec_tunnel.py
@@ -322,14 +322,14 @@ def main():
     parent.add(obj)
 
     # Apply the state.
-    changed = helper.apply_state(obj, listing, module)
+    changed, diff = helper.apply_state(obj, listing, module)
 
     # Commit.
     if commit and changed:
         helper.commit(module)
 
     # Done.
-    module.exit_json(changed=changed)
+    module.exit_json(changed=changed, diff=diff)
 
 
 if __name__ == '__main__':

--- a/plugins/modules/panos_log_forwarding_profile.py
+++ b/plugins/modules/panos_log_forwarding_profile.py
@@ -115,8 +115,8 @@ def main():
     obj = LogForwardingProfile(**spec)
     parent.add(obj)
 
-    changed = helper.apply_state(obj, listing, module)
-    module.exit_json(changed=changed, msg='Done')
+    changed, diff = helper.apply_state(obj, listing, module)
+    module.exit_json(changed=changed, diff=diff, msg='Done')
 
 
 if __name__ == '__main__':

--- a/plugins/modules/panos_log_forwarding_profile_match_list.py
+++ b/plugins/modules/panos_log_forwarding_profile_match_list.py
@@ -175,8 +175,8 @@ def main():
     obj = LogForwardingProfileMatchList(**spec)
     lfp.add(obj)
 
-    changed = helper.apply_state(obj, listing, module)
-    module.exit_json(changed=changed, msg='Done')
+    changed, diff = helper.apply_state(obj, listing, module)
+    module.exit_json(changed=changed, diff=diff, msg='Done')
 
 
 if __name__ == '__main__':

--- a/plugins/modules/panos_log_forwarding_profile_match_list_action.py
+++ b/plugins/modules/panos_log_forwarding_profile_match_list_action.py
@@ -183,8 +183,8 @@ def main():
     obj = LogForwardingProfileMatchListAction(**spec)
     ml.add(obj)
 
-    changed = helper.apply_state(obj, listing, module)
-    module.exit_json(changed=changed, msg='Done')
+    changed, diff = helper.apply_state(obj, listing, module)
+    module.exit_json(changed=changed, diff=diff, msg='Done')
 
 
 if __name__ == '__main__':

--- a/plugins/modules/panos_management_profile.py
+++ b/plugins/modules/panos_management_profile.py
@@ -202,12 +202,12 @@ def main():
         module.fail_json(msg='Failed refresh: {0}'.format(e))
 
     # Perform requested action.
-    changed = helper.apply_state(obj, profiles, module)
+    changed, diff = helper.apply_state(obj, profiles, module)
     if changed and module.params['commit']:
         helper.commit(module)
 
     # Done.
-    module.exit_json(changed=changed, msg="Done")
+    module.exit_json(changed=changed, diff=diff, msg="Done")
 
 
 if __name__ == '__main__':

--- a/plugins/modules/panos_nat_rule.py
+++ b/plugins/modules/panos_nat_rule.py
@@ -210,7 +210,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 
 
 from ansible.module_utils.basic import get_exception, AnsibleModule
-from ansible_collections.paloaltonetworks.panos.plugins.module_utils.panos import get_connection
+from ansible_collections.paloaltonetworks.panos.plugins.module_utils.panos import get_connection, eltostr
 
 
 try:
@@ -398,6 +398,7 @@ def main():
 
     # Perform the desired operation.
     changed = False
+    diff = None
     if state in ('enable', 'disable'):
         for rule in rules:
             if rule.name == new_rule.name:
@@ -409,7 +410,9 @@ def main():
         elif state == 'disable' and not rule.disabled:
             changed = True
         if changed:
+            diff = dict(before = eltostr(rule))
             rule.disabled = not rule.disabled
+            diff['after'] = eltostr(rule)
             if not module.check_mode:
                 try:
                     rule.update('disabled')
@@ -417,14 +420,14 @@ def main():
                     module.fail_json(msg='Failed enable: {0}'.format(e))
     else:
         parent.add(new_rule)
-        changed = helper.apply_state(new_rule, rules, module)
+        changed, diff = helper.apply_state(new_rule, rules, module)
         if state == 'present':
             changed |= helper.apply_position(new_rule, location, existing_rule, module)
 
     if changed and module.params['commit']:
         helper.commit(module)
 
-    module.exit_json(changed=changed, msg='Done')
+    module.exit_json(changed=changed, diff=diff, msg='Done')
 
 
 if __name__ == '__main__':

--- a/plugins/modules/panos_nat_rule.py
+++ b/plugins/modules/panos_nat_rule.py
@@ -410,7 +410,9 @@ def main():
         elif state == 'disable' and not rule.disabled:
             changed = True
         if changed:
-            diff = dict(before = eltostr(rule))
+            diff = dict(
+                before=eltostr(rule)
+            )
             rule.disabled = not rule.disabled
             diff['after'] = eltostr(rule)
             if not module.check_mode:

--- a/plugins/modules/panos_pbf_rule.py
+++ b/plugins/modules/panos_pbf_rule.py
@@ -300,14 +300,14 @@ def main():
     parent.add(new_rule)
 
     # Which action shall we take on the rule object?
-    changed = helper.apply_state(new_rule, rules, module)
+    changed, diff = helper.apply_state(new_rule, rules, module)
 
     # Move the rule to the correct spot, if applicable.
     if module.params['state'] == 'present':
         changed |= helper.apply_position(new_rule, location, existing_rule, module)
 
     # Done.
-    module.exit_json(changed=changed)
+    module.exit_json(changed=changed, diff=diff)
 
 
 if __name__ == '__main__':

--- a/plugins/modules/panos_pg.py
+++ b/plugins/modules/panos_pg.py
@@ -148,13 +148,13 @@ def main():
     parent.add(obj)
 
     # Apply the state.
-    changed = helper.apply_state(obj, listing, module)
+    changed, diff = helper.apply_state(obj, listing, module)
 
     # Optional commit.
     if changed and commit:
         helper.commit(module)
 
-    module.exit_json(changed=changed, msg='done')
+    module.exit_json(changed=changed, diff=diff, msg='done')
 
 
 if __name__ == '__main__':

--- a/plugins/modules/panos_redistribution.py
+++ b/plugins/modules/panos_redistribution.py
@@ -228,11 +228,11 @@ def main():
     listing = vr.findall(obj.__class__)
     vr.add(obj)
 
-    changed = helper.apply_state(obj, listing, module)
+    changed, diff = helper.apply_state(obj, listing, module)
     if changed and module.params['commit']:
         helper.commit(module)
 
-    module.exit_json(changed=changed, msg='done')
+    module.exit_json(changed=changed, diff=diff, msg='done')
 
 
 if __name__ == '__main__':

--- a/plugins/modules/panos_security_rule.py
+++ b/plugins/modules/panos_security_rule.py
@@ -462,7 +462,7 @@ def main():
     parent.add(new_rule)
 
     # Which action shall we take on the rule object?
-    changed = helper.apply_state(new_rule, rules, module)
+    changed, diff = helper.apply_state(new_rule, rules, module)
 
     # Move the rule to the correct spot, if applicable.
     if module.params['state'] == 'present':
@@ -473,7 +473,7 @@ def main():
         helper.commit(module)
 
     # Done.
-    module.exit_json(changed=changed, msg='Done')
+    module.exit_json(changed=changed, diff=diff, msg='Done')
 
 
 if __name__ == '__main__':

--- a/plugins/modules/panos_service_group.py
+++ b/plugins/modules/panos_service_group.py
@@ -137,14 +137,14 @@ def main():
     parent.add(obj)
 
     # Apply the state.
-    changed = helper.apply_state(obj, listing, module)
+    changed, diff = helper.apply_state(obj, listing, module)
 
     # Commit.
     if commit and changed:
         helper.commit(module)
 
     # Done.
-    module.exit_json(changed=changed)
+    module.exit_json(changed=changed, diff=diff)
 
 
 if __name__ == '__main__':

--- a/plugins/modules/panos_service_object.py
+++ b/plugins/modules/panos_service_object.py
@@ -159,14 +159,14 @@ def main():
     parent.add(obj)
 
     # Apply the state.
-    changed = helper.apply_state(obj, listing, module)
+    changed, diff = helper.apply_state(obj, listing, module)
 
     # Commit.
     if commit and changed:
         helper.commit(module)
 
     # Done.
-    module.exit_json(changed=changed)
+    module.exit_json(changed=changed, diff=diff)
 
 
 if __name__ == '__main__':

--- a/plugins/modules/panos_snmp_profile.py
+++ b/plugins/modules/panos_snmp_profile.py
@@ -111,8 +111,8 @@ def main():
     obj = SnmpServerProfile(**spec)
     parent.add(obj)
 
-    changed = helper.apply_state(obj, listing, module)
-    module.exit_json(changed=changed, msg='Done')
+    changed, diff = helper.apply_state(obj, listing, module)
+    module.exit_json(changed=changed, diff=diff, msg='Done')
 
 
 if __name__ == '__main__':

--- a/plugins/modules/panos_snmp_v2c_server.py
+++ b/plugins/modules/panos_snmp_v2c_server.py
@@ -125,8 +125,8 @@ def main():
     obj = SnmpV2cServer(**spec)
     sp.add(obj)
 
-    changed = helper.apply_state(obj, listing, module)
-    module.exit_json(changed=changed, msg='Done')
+    changed, diff = helper.apply_state(obj, listing, module)
+    module.exit_json(changed=changed, diff=diff, msg='Done')
 
 
 if __name__ == '__main__':

--- a/plugins/modules/panos_snmp_v3_server.py
+++ b/plugins/modules/panos_snmp_v3_server.py
@@ -142,8 +142,8 @@ def main():
     obj = SnmpV3Server(**spec)
     sp.add(obj)
 
-    changed = helper.apply_state(obj, listing, module)
-    module.exit_json(changed=changed, msg='Done')
+    changed, diff = helper.apply_state(obj, listing, module)
+    module.exit_json(changed=changed, diff=diff, msg='Done')
 
 
 if __name__ == '__main__':

--- a/plugins/modules/panos_static_route.py
+++ b/plugins/modules/panos_static_route.py
@@ -205,9 +205,9 @@ def main():
     vr.add(obj)
 
     # Apply the state.
-    changed = helper.apply_state(obj, listing, module)
+    changed, diff = helper.apply_state(obj, listing, module)
 
-    module.exit_json(changed=changed)
+    module.exit_json(changed=changed, diff=diff)
 
 
 if __name__ == '__main__':

--- a/plugins/modules/panos_syslog_profile.py
+++ b/plugins/modules/panos_syslog_profile.py
@@ -191,8 +191,8 @@ def main():
     obj = SyslogServerProfile(**spec)
     parent.add(obj)
 
-    changed = helper.apply_state(obj, listing, module)
-    module.exit_json(changed=changed, msg='Done')
+    changed, diff = helper.apply_state(obj, listing, module)
+    module.exit_json(changed=changed, diff=diff, msg='Done')
 
 
 if __name__ == '__main__':

--- a/plugins/modules/panos_syslog_server.py
+++ b/plugins/modules/panos_syslog_server.py
@@ -164,8 +164,8 @@ def main():
     obj = SyslogServer(**spec)
     sp.add(obj)
 
-    changed = helper.apply_state(obj, listing, module)
-    module.exit_json(changed=changed, msg='Done')
+    changed, diff = helper.apply_state(obj, listing, module)
+    module.exit_json(changed=changed, diff=diff, msg='Done')
 
 
 if __name__ == '__main__':

--- a/plugins/modules/panos_tag_object.py
+++ b/plugins/modules/panos_tag_object.py
@@ -136,12 +136,12 @@ def main():
     obj = Tag(**spec)
     parent.add(obj)
 
-    changed = helper.apply_state(obj, listing, module)
+    changed, diff = helper.apply_state(obj, listing, module)
 
     if commit and changed:
         helper.commit(module)
 
-    module.exit_json(changed=changed)
+    module.exit_json(changed=changed, diff=diff)
 
 
 if __name__ == '__main__':

--- a/plugins/modules/panos_tunnel.py
+++ b/plugins/modules/panos_tunnel.py
@@ -106,7 +106,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'supported_by': 'community'}
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.paloaltonetworks.panos.plugins.module_utils.panos import get_connection
+from ansible_collections.paloaltonetworks.panos.plugins.module_utils.panos import get_connection, eltostr
 
 
 try:
@@ -200,6 +200,7 @@ def main():
 
     # Which action should we take on the interface?
     changed = False
+    diff = None
     reference_params = {
         'refresh': True,
         'update': not module.check_mode,
@@ -209,10 +210,12 @@ def main():
         for item in interfaces:
             if item.name != obj.name:
                 continue
+            diff = dict( before = eltostr(item) )
             # Interfaces have children, so don't compare them.
             if not item.equal(obj, compare_children=False):
                 changed = True
                 obj.extend(item.children)
+                diff['after'] = eltostr(obj)
                 if not module.check_mode:
                     try:
                         obj.apply()
@@ -221,6 +224,10 @@ def main():
             break
         else:
             changed = True
+            diff = dict(
+                before = "",
+                after = eltostr(obj)
+            )
             if not module.check_mode:
                 try:
                     obj.create()
@@ -246,6 +253,10 @@ def main():
         # Remove the interface.
         if obj.name in [x.name for x in interfaces]:
             changed = True
+            diff = dict (
+                before = eltostr(obj),
+                after = ""
+            )
             if not module.check_mode:
                 try:
                     obj.delete()
@@ -257,7 +268,7 @@ def main():
         helper.commit(module)
 
     # Done!
-    module.exit_json(changed=changed, msg='Done')
+    module.exit_json(changed=changed, diff=diff, msg='Done')
 
 
 if __name__ == '__main__':

--- a/plugins/modules/panos_tunnel.py
+++ b/plugins/modules/panos_tunnel.py
@@ -210,7 +210,9 @@ def main():
         for item in interfaces:
             if item.name != obj.name:
                 continue
-            diff = dict( before = eltostr(item) )
+            diff = dict(
+                before=eltostr(item)
+            )
             # Interfaces have children, so don't compare them.
             if not item.equal(obj, compare_children=False):
                 changed = True
@@ -225,8 +227,8 @@ def main():
         else:
             changed = True
             diff = dict(
-                before = "",
-                after = eltostr(obj)
+                before="",
+                after=eltostr(obj)
             )
             if not module.check_mode:
                 try:
@@ -253,9 +255,9 @@ def main():
         # Remove the interface.
         if obj.name in [x.name for x in interfaces]:
             changed = True
-            diff = dict (
-                before = eltostr(obj),
-                after = ""
+            diff = dict(
+                before=eltostr(obj),
+                after=""
             )
             if not module.check_mode:
                 try:

--- a/plugins/modules/panos_zone.py
+++ b/plugins/modules/panos_zone.py
@@ -186,10 +186,10 @@ def main():
     parent.add(new_zone)
 
     # Perform the requeseted action.
-    changed = helper.apply_state(new_zone, zones, module)
+    changed, diff = helper.apply_state(new_zone, zones, module)
 
     # Done!
-    module.exit_json(changed=changed, msg='Done')
+    module.exit_json(changed=changed, diff=diff, msg='Done!')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Description

This adds support for running ```ansible-playbook --diff```, displaying the change in xml configuration on panos devices.

## Motivation and Context

Running a playbook with ```--check --diff``` allows you to verify changes before running a playbook for real.

## How Has This Been Tested?

Tested this on 2 production panos devices.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [] I have added tests to cover my changes if appropriate.
- [] All new and existing tests passed.
