### PR TITLE
Fix missing original option choice in BGP peer group plugin

### DIFF
--- a/plugins/modules/panos_bgp_peer_group.py
+++ b/plugins/modules/panos_bgp_peer_group.py
@@ -62,9 +62,9 @@ options:
         description:
             - Export locally resolved nexthop.
         choices:
-            - resolve
+            - original
             - use-self
-        default: 'resolve'
+        default: 'original'
     import_nexthop:
         description:
             - I(type=ebgp) only; override nexthop with peer address.
@@ -145,8 +145,8 @@ def setup_args():
             type='str', default='ebgp', choices=['ebgp', 'ibgp', 'ebgp-confed', 'ibgp-confed'],
             help='Peer group type I("ebgp")/I("ibgp")/I("ebgp-confed")/I("ibgp-confed")'),
         export_nexthop=dict(
-            type='str', default='resolve', choices=['resolve', 'use-self'],
-            help='Export locally resolved nexthop I("resolve")/I("use-self")'),
+            type='str', default='original', choices=['original', 'use-self'],
+            help='Export locally resolved nexthop I("original")/I("use-self")'),
         import_nexthop=dict(
             type='str', default='original', choices=['original', 'use-peer'],
             help='Override nexthop with peer address I("original")/I("use-peer"), only with "ebgp"'),


### PR DESCRIPTION
Fix missing original option choice in BGP peer group plugin

<!--- Provide a general summary of your changes in the Title above -->

"Resolve" option for BGP peer group Export Next Hop does not exist on Palo Alto.  
Must be "Original" or "Use Self".
Fixed this mistak in the plugin "panos_bgp_peer_group.py".

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

I was not able to configure BGP peer Export Next Hop option with value "Original"

<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

Made tests by creating a bgp peer group with export next hop option with value "original".

<!--- Include details of your testing environment, and the tests you ran to -->

<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

<!--- Drag any screenshots here -->


## Types of changes

<!--- What types of changes does your code introduce? -->
changed "resolve" option for "original" option.

<!--- Remove any that don't apply: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
