### PR TITLE
Dst zone as str

### DIFF
--- a/plugins/modules/panos_nat_rule.py
+++ b/plugins/modules/panos_nat_rule.py
@@ -28,6 +28,7 @@ author:
     - Robert Hagen (@rnh556)
     - Michael Richardson (@mrichardson03)
     - Garfield Lee Freeman (@shinmog)
+    - Ken Celenza (@itdependsnetworks)
 version_added: "2.4"
 requirements:
     - pan-python can be obtained from PyPI U(https://pypi.python.org/pypi/pan-python)
@@ -101,7 +102,7 @@ options:
     destination_zone:
         description:
             - destination zone
-        type: list
+        type: str
         required: true
     destination_ip:
         description:
@@ -287,7 +288,7 @@ def main():
             nat_type=dict(default='ipv4', choices=['ipv4', 'nat64', 'nptv6']),
             source_zone=dict(type='list'),
             source_ip=dict(type='list', default=['any']),
-            destination_zone=dict(),
+            destination_zone=dict(type='str'),
             destination_ip=dict(type='list', default=['any']),
             to_interface=dict(default='any'),
             service=dict(default='any'),


### PR DESCRIPTION
The module indicates a list is acceptable for destination_zone, but in reality it get's converted to an a string that looks like a json list that is not correct.

<!--- Provide a general summary of your changes in the Title above -->

## Description

Update destination_zone on NAT module

## Motivation and Context

It was not working as expected. 

## How Has This Been Tested?

Just locally, and copied over changes. 

## Screenshots (if appropriate)

<!--- Drag any screenshots here -->

## Types of changes

<!--- What types of changes does your code introduce? -->

<!--- Remove any that don't apply: -->

- Bug fix (non-breaking change which fixes an issue)


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x ] I have updated the documentation accordingly.
- [ x] I have read the **CONTRIBUTING** document.
- [ x] I have added tests to cover my changes if appropriate.
- [ x] All new and existing tests passed.
