### PR TITLE
panos_ike_gateway - Support dynamic IKE peer

### DIFF
--- a/plugins/modules/panos_ike_gateway.py
+++ b/plugins/modules/panos_ike_gateway.py
@@ -91,6 +91,11 @@ options:
         type: int
         default: 5
         aliases: 'liveness_check'
+    peer_ip_type:
+        description:
+            - IP or dynamic.
+        default: 'ip'
+        choices: ['ip', 'dynamic']
     peer_ip_value:
         description:
             - IPv4 address of the peer gateway.
@@ -220,6 +225,7 @@ def main():
             enable_fragmentation=dict(type='bool', default=False, aliases=['fragmentation']),
             enable_liveness_check=dict(type='bool', default=True),
             liveness_check_interval=dict(type='int', default=5, aliases=['liveness_check']),
+            peer_ip_type=dict(default='ip', choices=['ip', 'dynamic']),
             peer_ip_value=dict(default='127.0.0.1'),
             enable_dead_peer_detection=dict(type='bool', default=False, aliases=['dead_peer_detection']),
             dead_peer_detection_interval=dict(type='int', default=99),
@@ -263,6 +269,7 @@ def main():
         'enable_fragmentation': module.params['enable_fragmentation'],
         'enable_liveness_check': module.params['enable_liveness_check'],
         'liveness_check_interval': module.params['liveness_check_interval'],
+        'peer_ip_type': module.params['peer_ip_type'],
         'peer_ip_value': module.params['peer_ip_value'],
         'enable_dead_peer_detection': module.params['enable_dead_peer_detection'],
         'dead_peer_detection_interval': module.params['dead_peer_detection_interval'],

--- a/plugins/modules/panos_ike_gateway.py
+++ b/plugins/modules/panos_ike_gateway.py
@@ -134,7 +134,7 @@ options:
     local_id_type:
         description:
             - Specify the type of local ID.
-        choices: ['ipaddr', 'fwdn', 'ufqdn', 'keyid', 'dn']
+        choices: ['ipaddr', 'fqdn', 'ufqdn', 'keyid', 'dn']
         default: None
     local_id_value:
         description:
@@ -143,7 +143,7 @@ options:
     peer_id_type:
         description:
             - Specify the type of peer ID.
-        choices: ['ipaddr', 'fwdn', 'ufqdn', 'keyid', 'dn']
+        choices: ['ipaddr', 'fqdn', 'ufqdn', 'keyid', 'dn']
         default: None
     peer_id_value:
         description:
@@ -192,6 +192,19 @@ EXAMPLES = '''
     peer_ip_value: '1.2.3.4'
     pre_shared_key: 'CHANGEME'
     ikev2_crypto_profile: 'IKE-Ansible'
+<<<<<<< HEAD
+=======
+    commit: False
+
+- name: Create IKE gateway (dynamic)
+  panos_ike_gateway:
+    provider: '{{ device }}'
+    name: 'test-dynamic'
+    interface: 'ethernet1/1'
+    peer_ip_type: dynamic
+    pre_shared_key: 'CHANGEME'
+    commit: False
+>>>>>>> f002ae5... PR changes.
 '''
 
 RETURN = '''


### PR DESCRIPTION
## Description

Support for dynamic IKE peer in `panos_ike_gateway`.

## Motivation and Context

Partial for #10. Adding FQDN support will require pandevice changes. 

## How Has This Been Tested?

Tested against PAN-OS 8.1, 9.0.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
