### PR TITLE
Remove required lifetime param - fixes #40.

### DIFF
--- a/plugins/modules/panos_ipsec_profile.py
+++ b/plugins/modules/panos_ipsec_profile.py
@@ -130,9 +130,6 @@ def main():
         template_stack=True,
         with_classic_provider_spec=True,
         with_state=True,
-        required_one_of=[
-            ['lifetime_seconds', 'lifetime_minutes', 'lifetime_hours', 'lifetime_days']
-        ],
         argument_spec=dict(
             name=dict(required=True),
             esp_encryption=dict(


### PR DESCRIPTION
## Description

Removed lifetime as an Ansible required parameter, was breaking removal of IPsec profiles unless one was specified.  Module already uses a default value (1 hour) if none is specified when adding a profile.

## How Has This Been Tested?

Tested against PAN-OS 10.0.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
