### PR TITLE
panos_type_cmd - Fix return value when XPATH returns list.

### DIFF
--- a/plugins/modules/panos_type_cmd.py
+++ b/plugins/modules/panos_type_cmd.py
@@ -143,6 +143,7 @@ try:
     from pandevice.errors import PanDeviceError
     import xmltodict
     import json
+    import xml
 except ImportError:
     pass
 
@@ -208,7 +209,10 @@ def main():
     json_output = None
 
     if xml_output is not None:
-        obj_dict = xmltodict.parse(xml_output)
+        try:
+            obj_dict = xmltodict.parse(xml_output)
+        except xml.parsers.expat.ExpatError:
+            obj_dict = xmltodict.parse('<entries>' + xml_output + '</entries>')['entries']
         json_output = json.dumps(obj_dict)
 
     if cmd in safecmd:

--- a/plugins/modules/panos_type_cmd.py
+++ b/plugins/modules/panos_type_cmd.py
@@ -143,7 +143,7 @@ try:
     from pandevice.errors import PanDeviceError
     import xmltodict
     import json
-    import xml
+    from xml.parsers.expat import ExpatError
 except ImportError:
     pass
 
@@ -211,7 +211,7 @@ def main():
     if xml_output is not None:
         try:
             obj_dict = xmltodict.parse(xml_output)
-        except xml.parsers.expat.ExpatError:
+        except ExpatError:
             obj_dict = xmltodict.parse('<entries>' + xml_output + '</entries>')['entries']
         json_output = json.dumps(obj_dict)
 


### PR DESCRIPTION
## Description

Work around in case the requested XPATH returns a list rather than a single element.  Fixes #38.

## How Has This Been Tested?

Tested against PAN-OS 10.0.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes if appropriate.
- [X] All new and existing tests passed.
