### PR TITLE
Update panos_facts to support Panorama.  Fixes #62.

### DIFF
--- a/plugins/modules/panos_facts.py
+++ b/plugins/modules/panos_facts.py
@@ -473,7 +473,6 @@ PANORAMA_SUBSETS = dict(
 def main():
     helper = get_connection(
         with_classic_provider_spec=True,
-        # panorama_error='This module is for firewall facts only',
         argument_spec=dict(
             gather_subset=dict(default=['!config'], type='list'),
 


### PR DESCRIPTION
## Description

`panos_facts` did not support Panorama.  This allows the module to gather the appropriate subsets on Panorama (system, ha, and config).

## How Has This Been Tested?

Tested against PAN-OS 9.0 and 10.0.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes if appropriate.
- [X] All new and existing tests passed.
