### PR TITLE
fix(panos_administrator): Add template_is_optional flag

### DIFF
--- a/plugins/modules/panos_administrator.py
+++ b/plugins/modules/panos_administrator.py
@@ -147,6 +147,7 @@ def main():
     helper = get_connection(
         template=True,
         template_stack=True,
+        template_is_optional=True,
         with_state=True,
         with_classic_provider_spec=True,
         min_pandevice_version=(0, 8, 0),


### PR DESCRIPTION
## Description

`panos_administrator` could only add administrators to a template, not Panorama itself.  This uses the new `template_is_optional` flag to allow the module to modify Panorama directly.

## How Has This Been Tested?

Tested on PAN-OS 10.0.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
