### PR TITLE
fix: Don't look up tag color when state is absent

### DIFF
--- a/plugins/modules/panos_tag_object.py
+++ b/plugins/modules/panos_tag_object.py
@@ -127,7 +127,7 @@ def main():
         with_state=True,
         argument_spec=dict(
             name=dict(type='str', required=True),
-            color=dict(type='str', choices=COLOR_NAMES),
+            color=dict(type='str', default=None, choices=COLOR_NAMES),
             comments=dict(type='str'),
             commit=dict(type='bool', default=False)
         )
@@ -143,9 +143,11 @@ def main():
 
     spec = {
         'name': module.params['name'],
-        'color': Tag.color_code(module.params['color']),
         'comments': module.params['comments']
     }
+
+    if module.params['color']:
+        spec['color'] = Tag.color_code(module.params['color'])
 
     commit = module.params['commit']
 


### PR DESCRIPTION
Fixes #26