### PR TITLE
fix: address_prefix should be list of type dict

### DIFF
--- a/plugins/modules/panos_bgp_policy_rule.py
+++ b/plugins/modules/panos_bgp_policy_rule.py
@@ -191,10 +191,9 @@ options:
         type: int
     address_prefix:
         description:
-            - List of address prefix strings or dicts with "name"/"exact" keys.
-            - If a list entry is a string, then I(exact=False) for that name.
+            - List of address prefix dicts with "name"/"exact" keys.
         type: list
-        elements: str
+        elements: dict
     vr_name:
         description:
             - Name of the virtual router; it must already exist; see M(panos_virtual_router).
@@ -218,7 +217,7 @@ EXAMPLES = '''
       enable: true
       action: 'allow'
       address_prefix:
-        - '10.1.1.0/24'
+        - name: '10.1.1.0/24'
         - name: '10.1.2.0/24'
           exact: false
         - name: '10.1.3.0/24'
@@ -304,7 +303,7 @@ def setup_args():
         action_extended_community_argument=dict(type='str'),
         action_dampening=dict(type='str'),
         action_weight=dict(type='int'),
-        address_prefix=dict(type='list', elements='str'),
+        address_prefix=dict(type='list', elements='dict'),
     )
 
 
@@ -373,15 +372,12 @@ def main():
 
     # Handle address prefixes.
     for x in module.params['address_prefix']:
-        if isinstance(x, dict):
-            if 'name' not in x:
-                module.fail_json(msg='Address prefix dict requires "name": {0}'.format(x))
-            obj.add(BgpPolicyAddressPrefix(
-                to_text(x['name'], encoding='utf-8', errors='surrogate_or_strict'),
-                None if x.get('exact') is None else module.boolean(x['exact']),
-            ))
-        else:
-            obj.add(BgpPolicyAddressPrefix(to_text(x, encoding='utf-8', errors='surrogate_or_strict')))
+        if 'name' not in x:
+            module.fail_json(msg='Address prefix dict requires "name": {0}'.format(x))
+        obj.add(BgpPolicyAddressPrefix(
+            to_text(x['name'], encoding='utf-8', errors='surrogate_or_strict'),
+            None if x.get('exact') is None else module.boolean(x['exact']),
+        ))
 
     listing = bgp.findall(obj.__class__)
     bgp.add(obj)


### PR DESCRIPTION
Fixes #116

## Description

`panos_bgp_policy_rule` had an option `address_prefix` that was treated as a list of either strings or dicts.  This actually breaks sanity checks:

- Options should only have one type
- If the type is list, elements should only have one type

This change removes the code handling the string elements case, and makes the option be a list of dicts.

## Motivation and Context

See below.

## Types of changes

See below (TBD):

- Bug fix (non-breaking change which fixes an issue)
- Breaking change (fix or feature that would cause existing functionality to change)


