### PR TITLE
fix: panos_security_rule facts should support 'shared'

### DIFF
--- a/plugins/modules/panos_security_rule_facts.py
+++ b/plugins/modules/panos_security_rule_facts.py
@@ -297,7 +297,6 @@ def main():
         device_group=True,
         rulebase=True,
         with_classic_provider_spec=True,
-        error_on_shared=True,
         argument_spec=dict(
             rule_name=dict(),
             all_details=dict(default=False, type='bool'),


### PR DESCRIPTION
Fixes #91
