### PR TITLE
fix(panos_custom_url_category): Don't use type parameter

### DIFF
--- a/plugins/modules/panos_custom_url_category.py
+++ b/plugins/modules/panos_custom_url_category.py
@@ -50,7 +50,7 @@ options:
         elements: str
     type:
         description:
-            - Custom category type
+            - Custom category type (currently unused)
         type: str
         choices: ['URL List', 'Category Match']
         default: 'URL List'
@@ -64,7 +64,6 @@ EXAMPLES = '''
     url_value:
         - microsoft.com
         - redhat.com
-    type: "URL List"
 
 - name: Remove Custom Url Category 'Internet Access List'
   panos_tag_object:
@@ -116,11 +115,11 @@ def main():
     )
 
     parent = helper.get_pandevice_parent(module)
+    device = parent.nearest_pandevice()
 
     spec = {
         'name': module.params['name'],
         'url_value': module.params['url_value'],
-        'type': module.params['type']
     }
 
     try:

--- a/tests/integration/firewall/test_panos_custom_url_category.yml
+++ b/tests/integration/firewall/test_panos_custom_url_category.yml
@@ -1,6 +1,10 @@
 ---
 - include_tasks: 'reset.yml'
 
+- name: test_panos_custom_url_category - Gather PAN-OS facts
+  panos_facts:
+    provider: '{{ device }}'
+
 - name: test_panos_custom_url_category - Create
   panos_custom_url_category:
     provider: '{{ device }}'


### PR DESCRIPTION
pan-os-python doesn't properly support category matches in CustomUrlCategory yet, so don't use this parameter until it does.

Fixes #143
