### PR TITLE
panos_software download optimization

### DIFF
--- a/plugins/modules/panos_software.py
+++ b/plugins/modules/panos_software.py
@@ -178,8 +178,6 @@ def main():
                 if restart:
                     device.restart()
 
-
-
     except PanDeviceError as e:
         module.fail_json(msg=e.message)
 


### PR DESCRIPTION
## Description

panos_software module always downloads software even if it has already been downloaded. This patch adds a simple check before initiating the downloading. For upgrade / downgrade playbooks this saves a considerable amount of time.

## Motivation and Context

Currently upgrades and downgrades much ensure the initial major release is present on the box. The current behavioure forces a lengthy redownload every time the playbook is run. This patch only downloads software if it is not already downloaded on the device. 

## How Has This Been Tested?

Collection installed locally and software upgrade downgrades performed

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- New feature (non-breaking change which adds functionality)


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [*] I have updated the documentation accordingly.
- [*] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
