### PR TITLE
Don't recommend deprecated pandevice dependency

### DIFF
--- a/plugins/module_utils/panos.py
+++ b/plugins/module_utils/panos.py
@@ -114,7 +114,7 @@ class ConnectionHelper(object):
         """
         # Sanity check.
         if not HAS_PANDEVICE:
-            module.fail_json(msg='Missing required library "pandevice".')
+            module.fail_json(msg='Missing required library "pan-os-python".')
 
         pdv = tuple(int(x) for x in panos.__version__.split('.'))
 


### PR DESCRIPTION
## Description

related to #129 

https://github.com/PaloAltoNetworks/pan-os-ansible/blob/af9faa4f6f18b421f5a14656adb81e84c35eb333/plugins/module_utils/panos.py#L117 still suggests installing pandevice. once that's installed the deprecation warning shows up:
```
[DEPRECATION WARNING]: Python library "pandevice" is now "pan-os-python" and is now 1.0! Please "pip install pan-os-python" at your earliest convenience. This feature will be removed from paloaltonetworks.panos in version 3.0.0.
Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
```

## Motivation and Context

`pandevice` is deprecated in favor of `pan-os-python`.

## How Has This Been Tested?

It is just an update to the message shown to the user.

## Screenshots (if appropriate)

-

## Types of changes

- Documentation(?)

## Checklist

- [x] I have updated the documentation accordingly.
I don't think this needs documentation updates anywhere.
- [ ] I have read the **CONTRIBUTING** document.
I'm unable to find this document. It's not located in the root of the git repo at least.
- [x] I have added tests to cover my changes if appropriate.
No tests needed.
- [x] All new and existing tests passed.
Unless there is a test specifically expecting this to ask for pandevice this should be fine.