### PR TITLE
Virtual router idempotent fix - Issue #191

### DIFF
--- a/plugins/modules/panos_virtual_router.py
+++ b/plugins/modules/panos_virtual_router.py
@@ -195,7 +195,6 @@ def main():
         "update": not module.check_mode,
         "return_type": "bool",
     }
-
     changed = False
     if state == "present":
         for item in vr_list:
@@ -206,6 +205,7 @@ def main():
             for x in other_children:
                 if x in item.children:
                     item.children.remove(x)
+            other_interface = []
             if virtual_router.interface and item.interface:
                 other_interface = [x for x in item.interface if x not in virtual_router.interface]
                 for x in other_interface:

--- a/plugins/modules/panos_virtual_router.py
+++ b/plugins/modules/panos_virtual_router.py
@@ -103,7 +103,14 @@ RETURN = """
 """
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.paloaltonetworks.panos.plugins.module_utils.panos import (
+# from ansible_collections.paloaltonetworks.panos.plugins.module_utils.panos import (
+#     get_connection,
+# )
+import os, sys
+currentdir = os.path.dirname(os.path.realpath(__file__))
+parentdir = os.path.dirname(currentdir)
+sys.path.append(parentdir)
+from module_utils.panos import (
     get_connection,
 )
 
@@ -133,6 +140,15 @@ def setup_args():
         ad_ebgp=dict(type="int"),
         ad_rip=dict(type="int"),
     )
+
+
+def eltostr(obj):
+    try:
+        # Try pretty print first if pandevice supports it
+        return obj.element_str(pretty_print=True)
+    except TypeError:
+        # Fall back to normal
+        return obj.element_str()
 
 
 def main():
@@ -195,19 +211,52 @@ def main():
         "update": not module.check_mode,
         "return_type": "bool",
     }
+
     changed = False
+    diff = None
     if state == "present":
+        # Get the diff state
+        changed, diff = helper.apply_state(virtual_router, vr_list, module)
         for item in vr_list:
             if item.name != name:
                 continue
-            if not item.equal(virtual_router, compare_children=False):
+            diff = dict(before=eltostr(item))
+            obj_child_types = [x.__class__ for x in virtual_router.children]
+            other_children = []
+            other_interface = []
+            for x in item.children:
+                if x.__class__ in obj_child_types:
+                    continue
+                other_children.append(x)
+                item.remove(x)
+            if virtual_router.interface and item.interface:
+                for x in item.interface:
+                    if x in virtual_router.interface:
+                        other_interface.append(x)
+                        item.interface.remove(x)
+            elif virtual_router.interface and not item.interface:
+                other_interface = virtual_router.interface
+            elif not virtual_router.interface and not item.interface:
+                other_interface = item.interface
+                item.interface = None
+            if not item.equal(virtual_router, compare_children=True):
                 changed = True
-                virtual_router.extend(item.children)
+                virtual_router.extend(other_children)
+                virtual_router.interface = other_interface
+                diff["after"] = eltostr(virtual_router)
                 if not module.check_mode:
                     try:
                         virtual_router.apply()
                     except PanDeviceError as e:
                         module.fail_json(msg="Failed apply: {0}".format(e))
+                #if not item.equal(virtual_router, compare_children=False):
+                # changed = True
+                # virtual_router.extend(item.children)
+                # if not module.check_mode:
+                #     try:
+                #         virtual_router.apply()
+                #     except PanDeviceError as e:
+                #         module.fail_json(msg="Failed apply: {0}".format(e))
             break
         else:
             changed = True

--- a/plugins/modules/panos_virtual_router.py
+++ b/plugins/modules/panos_virtual_router.py
@@ -201,13 +201,17 @@ def main():
             if item.name != name:
                 continue
             obj_child_types = [x.__class__ for x in virtual_router.children]
-            other_children = [x for x in item.children if x.__class__ not in obj_child_types]
+            other_children = [
+                x for x in item.children if x.__class__ not in obj_child_types
+            ]
             for x in other_children:
                 if x in item.children:
                     item.children.remove(x)
             other_interface = []
             if virtual_router.interface and item.interface:
-                other_interface = [x for x in item.interface if x not in virtual_router.interface]
+                other_interface = [
+                    x for x in item.interface if x not in virtual_router.interface
+                ]
                 for x in other_interface:
                     item.interface.remove(x)
             elif virtual_router.interface and not item.interface:

--- a/plugins/modules/panos_virtual_router.py
+++ b/plugins/modules/panos_virtual_router.py
@@ -207,23 +207,9 @@ def main():
             for x in other_children:
                 if x in item.children:
                     item.children.remove(x)
-            other_interface = []
-            if virtual_router.interface and item.interface:
-                other_interface = [
-                    x for x in item.interface if x not in virtual_router.interface
-                ]
-                for x in other_interface:
-                    item.interface.remove(x)
-            elif virtual_router.interface and not item.interface:
-                other_interface = virtual_router.interface
-            elif not virtual_router.interface and not item.interface:
-                # ensure both values are Null
-                other_interface = None
-                item.interface = None
             if not item.equal(virtual_router, compare_children=True):
                 changed = True
                 virtual_router.extend(other_children)
-                virtual_router.interface.extend(other_interface)
                 if not module.check_mode:
                     try:
                         virtual_router.apply()


### PR DESCRIPTION
## Description

Updated the ```panos_virtual_router.py``` module to fix idempotency.  

**EDIT:** I am removing the interface changes from this pull so that it does not change current behavior.  This pull only include a fix when there are more than one child objects.

1. Module will no longer detect a change when a child object (BGP, OSPF, Static route, etc) is configured.
<s>2. Module will no longer detect a change when an interface is added to the virtual router outside of this module</s>

## Motivation and Context

See [Issue #191 for details](https://github.com/PaloAltoNetworks/pan-os-ansible/issues/191)

## How Has This Been Tested?

I'm currently testing against a Lab Panorama VE instance.  I'm also testing locally using a venv python 3.7 & ansible 2.10.  

I've run the following test scenarios which have passed.

1. Create net new Virtual Router with all arguments populated
2. Change argument to VR in playbook - Pass
<s>3. Add a new interface to VR in playbook - Pass
4. Manually add interface to VR, run playbook to validate no change detected - Pass
       - Manually add new interface to VR, Add new interface to playbook, run playbook and verify:
       - Manually added interface is NOT removed - Pass
7. Ansible added interface is added - Pass</s>
8. Manually add OSPF & BGP policy, run play book to verify no change is detected - Pass

## Screenshots (if appropriate)

![Screen Shot 2021-02-13 at 1 30 34 PM](https://user-images.githubusercontent.com/1187042/107857979-b2df5180-6dff-11eb-858c-2acc974e1dba.png)


## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

I am currently running the integration tests and will upload my results shortly

- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [X ] All new and existing tests passed.
