### PR TITLE
Panos zone idempotency fix

### DIFF
--- a/plugins/modules/panos_zone.py
+++ b/plugins/modules/panos_zone.py
@@ -197,6 +197,21 @@ def main():
     new_zone = Zone(**zone_spec)
     parent.add(new_zone)
 
+    # Account for interfaces configured outside this module
+    for item in zones:
+        if item.name != new_zone.name:
+            continue
+        other_interface = []
+        if new_zone.interface and item.interface:
+            other_interface = [
+                x for x in item.interface if x not in new_zone.interface
+            ]
+            for x in other_interface:
+                item.interface.remove(x)
+        elif not new_zone.interface and item.interface:
+            other_interface = item.interface
+        new_zone.interface.extend(other_interface)
+
     # Perform the requeseted action.
     changed, diff = helper.apply_state(new_zone, zones, module)
 

--- a/plugins/modules/panos_zone.py
+++ b/plugins/modules/panos_zone.py
@@ -210,7 +210,7 @@ def main():
             other_interface = item.interface
         new_zone.interface.extend(other_interface)
 
-    # Perform the requeseted action.
+    # Perform the requested action.
     changed, diff = helper.apply_state(new_zone, zones, module)
 
     # Done!

--- a/plugins/modules/panos_zone.py
+++ b/plugins/modules/panos_zone.py
@@ -60,7 +60,7 @@ options:
         default: "layer3"
     interface:
         description:
-            - List of member interfaces.
+            - List of member interfaces.  Interfaces can be added to a zone but not removed with this module.
         type: list
         elements: str
     zone_profile:
@@ -198,16 +198,14 @@ def main():
     parent.add(new_zone)
 
     # Account for interfaces configured outside this module
+    if not new_zone.interface:
+        new_zone.interface = []
     for item in zones:
         if item.name != new_zone.name:
             continue
         other_interface = []
         if new_zone.interface and item.interface:
-            other_interface = [
-                x for x in item.interface if x not in new_zone.interface
-            ]
-            for x in other_interface:
-                item.interface.remove(x)
+            other_interface = [x for x in item.interface if x not in new_zone.interface]
         elif not new_zone.interface and item.interface:
             other_interface = item.interface
         new_zone.interface.extend(other_interface)


### PR DESCRIPTION
## Description

Updated the panos_zone.py module to fix idempotency.

- Module will no longer detect a change & overwrite interfaces added to a zone outside of this module.
- Module will no longer remove interfaces from a zone at all and will only add.


## Motivation and Context

See [Issue #193](https://github.com/PaloAltoNetworks/pan-os-ansible/issues/193)

When building a comprehensive playbook to fully configure network settings i've found this module is capable of overwriting settings set by another module or set manually.  For example, i should be able to manage my zone assignments using the panos_interface module without having to maintain the list of interfaces with this module.  

Additionally, i should be able to add & manage an interfaces manually via the GUI without this module overwriting manual changes.  For this scenario it seems necessary to trade functionality for flexibility when working with a non-idempotent API like the PANOS XML API.  Practically speaking, it's possible to cause an outage by unexpectedly removing a zone from an interface, especially as more network engineers adopt devops tools.  


## How Has This Been Tested?

I've run the following scenarios.

- Create net new zone w/o Interface - Pass
 	- Run a second time, verify no change detected - Pass
- Manually add interface, run playbook & verify it does NOT detect a change - Pass
- Add interface using the module, run playbook and verify:
 	- New interface is added - Pass
 	- Existing interface is not removed - Pass
 	- Run again, no change detected - Pass


## Screenshots (if appropriate)


## Types of changes

- Breaking change (fix or feature that would cause existing functionality to change)
 	- Breaking: No longer allows interfaces to be removed from a zone (unless the state is absent)
 	- Fix: No longer overwrites interfaces zone assignments managed outside of this module

## Checklist

- [ x ] I have updated the documentation accordingly.
- [ x ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
