### PR TITLE
panos.py apply_state fix

### DIFF
--- a/plugins/module_utils/panos.py
+++ b/plugins/module_utils/panos.py
@@ -398,12 +398,12 @@ class ConnectionHelper(object):
                     continue
                 diff = dict(before=eltostr(item))
                 obj_child_types = [x.__class__ for x in obj.children]
-                other_children = []
-                for x in item.children:
-                    if x.__class__ in obj_child_types:
-                        continue
-                    other_children.append(x)
-                    item.remove(x)
+                other_children = [
+                    x for x in item.children if x.__class__ not in obj_child_types
+                ]
+                for x in other_children:
+                    if x in item.children:
+                        item.children.remove(x)
                 if not item.equal(obj, compare_children=True):
                     changed = True
                     obj.extend(other_children)


### PR DESCRIPTION
## Description

This pull changes the `apply_state` function in ..plugins/module_utils/panos.py.  The current version mutates the item.children object which causes idempotency issues for objects with multiple children (i.e. bgp peer group members).  This fix creates a new object from item.children to traverse while removing existing entries from item.children.

## Motivation and Context

This resolves [issue #4](https://github.com/PaloAltoNetworks/pan-os-ansible/issues/4)

## How Has This Been Tested?

Tested with a playbook to configure a bgp peer group with two members.  The before the fix when you re-run the playbook it will detects a change with the peer group task.  After the fix it no longer detects a change.  I also verified that attribute changes to peer members triggers a change.

Additionally, i ran the integration tests and all firewall tests passed.  one of the Panorama tests failed but i suspect that's due to an environment drift that i dont have time to research.

```
---
- name: Palo Idempotent Testing with BGP
  hosts: lab
  gather_facts: no
  connection: local
  collections:
    - paloaltonetworks.panos

  vars:
    pan:
      ip_address: 'slab-ndo-panorama.coxautoinc.com'
      username: 'admin'
      password: '*****'

  tasks:
  - name: Configure BGP Global Options
    panos_bgp:
      provider: '{{ pan }}'
      template: ANSIBLE-TEST
      vr_name: TEST_router
      router_id: 1.1.1.2
      local_as: 39334
      as_format: 4-byte
    delegate_to: localhost
    no_log: False

  - name: Configure BGP Peer Group
    panos_bgp_peer_group:
      provider: '{{ pan }}'
      template: ANSIBLE-TEST
      vr_name: TEST_router
      name: edge-routers
      type: ibgp
      export_nexthop: use-self
      aggregated_confed_as_path: yes
      soft_reset_with_stored_info: no
    delegate_to: localhost
    no_log: False

  - name: Configure BGP Peer Group Members
    panos_bgp_peer:
      provider: '{{ pan }}'
      template: ANSIBLE-TEST
      vr_name: TEST_router
      peer_group: edge-routers
      name: router01
      local_interface: ethernet1/1.200
      peer_address_ip: 192.168.132.114
      connection_incoming_remote_port: 0
      connection_incoming_allow: True
      connection_outgoing_local_port: 0
      connection_outgoing_allow: True
      connection_multihop: 0
      connection_keep_alive_interval: 30
      connection_open_delay_time: 30
      connection_hold_time: 90
      connection_idle_hold_time: 15
      connection_min_route_adv_interval: 30
      subsequent_address_unicast: True
      subsequent_address_multicast: False
      bfd_profile: Inherit-vr-global-setting
    delegate_to: localhost
    no_log: False

  - name: Configure BGP Peer Group Members
    panos_bgp_peer:
      provider: '{{ pan }}'
      template: ANSIBLE-TEST
      vr_name: TEST_router
      peer_group: edge-routers
      name: router02
      local_interface: ethernet1/1.200
      peer_address_ip: 192.168.132.115
      connection_incoming_remote_port: 0
      connection_incoming_allow: True
      connection_outgoing_local_port: 0
      connection_outgoing_allow: True
      connection_multihop: 0
      connection_keep_alive_interval: 30
      connection_open_delay_time: 30
      connection_hold_time: 90
      connection_idle_hold_time: 15
      connection_min_route_adv_interval: 30
      subsequent_address_unicast: True
      subsequent_address_multicast: False
      bfd_profile: Inherit-vr-global-setting
    delegate_to: localhost
    no_log: False
```

## Screenshots (if appropriate)

### Before the fix

<img width="1416" alt="Screen Shot 2021-03-18 at 7 06 34 PM" src="https://user-images.githubusercontent.com/1187042/111709334-ce35e600-881d-11eb-9f2e-292fdeaf642a.png">


### After the fix

<img width="1417" alt="Screen Shot 2021-03-18 at 7 02 34 PM" src="https://user-images.githubusercontent.com/1187042/111709351-d42bc700-881d-11eb-8d45-7f9627665101.png">



## Types of changes

- Bug fix (non-breaking change which fixes an issue)


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ x ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ x ] All new and existing tests passed#4 

