### PR TITLE
Added option to import a SAML metadata profile.

### DIFF
--- a/plugins/modules/panos_import.py
+++ b/plugins/modules/panos_import.py
@@ -62,6 +62,7 @@ options:
             - global-protect-portal-custom-login-page
             - global-protect-portal-custom-welcome-page
             - high-availability-key
+            - idp-metadata
             - keypair
             - license
             - logdb
@@ -112,6 +113,10 @@ options:
         aliases:
             - file
         required: false
+    profile_name:
+        description:
+            - When I(category=idp-metadata), the name of the SAML profile to create.
+        type: str
     url:
         description:
             - URL of the file that will be imported to device.
@@ -158,6 +163,13 @@ EXAMPLES = """
     category: 'custom-logo'
     custom_logo_location: 'login-screen'
     filename: '/tmp/logo.jpg'
+
+- name: Import SAML metadata profile
+  panos_import:
+    provider: '{{ device }}'
+    category: 'idp-metadata'
+    filename: '/tmp/saml_metadata.xml'
+    profile_name: 'saml-profile'
 """
 
 RETURN = """
@@ -179,7 +191,6 @@ try:
     import pan.xapi
     import requests
     import requests_toolbelt
-
     HAS_LIB = True
 except ImportError:
     HAS_LIB = False
@@ -238,6 +249,7 @@ def main():
                     "global-protect-portal-custom-login-page",
                     "global-protect-portal-custom-welcome-page",
                     "high-availability-key",
+                    "idp-metadata",
                     "keypair",
                     "license",
                     "logdb",
@@ -270,6 +282,7 @@ def main():
                     "pdf-report-header",
                 ],
             ),
+            profile_name=dict(type="str"),
             filename=dict(type="str", aliases=["file"]),
             url=dict(),
         ),
@@ -308,6 +321,9 @@ def main():
 
     elif category == "custom-logo":
         params["where"] = module.params["custom_logo_location"]
+
+    elif category == "idp-metadata":
+        params["profile-name"] = module.params["profile_name"]
 
     try:
         if not module.check_mode:

--- a/plugins/modules/panos_import.py
+++ b/plugins/modules/panos_import.py
@@ -191,6 +191,7 @@ try:
     import pan.xapi
     import requests
     import requests_toolbelt
+
     HAS_LIB = True
 except ImportError:
     HAS_LIB = False


### PR DESCRIPTION
## Description
I have added a new category option to enable uploading SAML metadata configuration to pan-os. 

All changes are in the file  ./plugins/modules/panos_import.py

Changes:

- Added "idp-metadata" as an optional category.
- Added "profile_name" as an option which is required when importing SAML metadata files.
- Added an example for SAML import.
- 
idp-metadata is the category defined in the api and profile-name is a required parameter for that category.
Documentation used for finding the category and parameter: [paloaltonetworks configure saml 2.0 xml api](https://docs.paloaltonetworks.com/pan-os/8-1/pan-os-panorama-api/pan-os-xml-api-use-cases/configure-saml-20-authentication-api.html)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This solves my issue of not being able to import a SAML metadata configuration I'm getting from Azure to configure SSO.
I tried using the certificate category but that, obviously to me now, does not work.
Since it make a certificate after importing the metadata i did consider putting it under that category, but the API category is different and it technically only makes the certificate after the SAML metadata import is done I made a new category.
<!--- If it fixes an open issue, please link to the issue here. -->
No open issue about this.
## How Has This Been Tested?
This has been tested on Panorama and directly on panos firewalls version 9.1.8 and once on 10.0.5.
I have tested that previous categories still works without issues. 
I have tested that there is errors when using the idp-metadata category without adding the profile_name option.

## Screenshots (if appropriate)

Example of some of the tasks I have ran:
![image](https://user-images.githubusercontent.com/30187002/116412725-41784200-a837-11eb-8aa1-1bb35c86d4dd.png)

ansible-playbook run:
![image](https://user-images.githubusercontent.com/30187002/116412891-64a2f180-a837-11eb-81b7-0c463bcd32dd.png)

As we can see the third task gets an error which is intended as it does not have the profile_name parameter included.

SAML Profile in Panorama:
![image](https://user-images.githubusercontent.com/30187002/116413141-a2077f00-a837-11eb-8643-10da52af32c5.png)

We can see here the profile has been made with the name from the task.

SAML Certificate in Panorama:
![image](https://user-images.githubusercontent.com/30187002/116413352-d24f1d80-a837-11eb-97bf-c0fe32d5437e.png)

And we can see that there is now a certificate after importing the metadata.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ x ] I have updated the documentation accordingly.
- [ x ] I have read the **CONTRIBUTING** document.
- [ - ] I have added tests to cover my changes if appropriate. - No tests exist for  the import module. The error handling already present deals with the errors that might come up.
- [ x ] All new and existing tests passed.
