### PR TITLE
panos_facts: fixed addition of ipv6 addresses to subinterfaces

### DIFF
--- a/plugins/modules/panos_facts.py
+++ b/plugins/modules/panos_facts.py
@@ -380,8 +380,8 @@ class Interfaces(Factbase):
                             "ipv6": [],
                         }
                         for sub_child in child.children:
-                            if isinstance(child, IPv6Address):
-                                child_info["ipv6"].append(sub_child.name)
+                            if isinstance(sub_child, IPv6Address):
+                                child_info["ipv6"].append(sub_child.uid)
                         interfaces.append(child_info)
                 interfaces.append(iface_info)
 


### PR DESCRIPTION
## Description

In the module `panos_facts.py`, the method `Interfaces` is, amongst other things, supposed to add the configured ipv6 addresses to the interfaces. For subinterfaces this doesn't work though, because instead of checking the type of the subinterface children to be `IPv6Address`, the method checks the type of the subinterface itself, therefore never adding ipv6 addresses to subinterfaces. The implemented fix is basically based on the code that adds ipv6 addresses to "normal" layer 3 interfaces which is also part of the `Interfaces` method.

## Motivation and Context

While gathering information about different systems with `panos_facts.py`, I noticed the following:
Without the changes, the module never adds any ipv6 address to subinterfaces, even though the code aims to do that. With the changes, the module is now working as intended and adds configured ipv6 addresses to the interface object.

## How Has This Been Tested?
On an Ansible control node running Python 3.7 and ansible 2.10.8, Palo Alto Firewall PA850 running version 9.1.9.

1. Add a Layer 3 Subinterface to an existing interface on a Palo Alto Firewall
2. Add one or more ipv6 addresses to that subinterface
3. Running the module without the changes will result in an empty list as value for the "ipv6"-attribute
4. Running the module with the changes will result in an correctly populated list as value for the "ipv6"-attribute

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [X] All new and existing tests passed.
