### PR TITLE
Feature/import to template

### DIFF
--- a/plugins/modules/panos_import.py
+++ b/plugins/modules/panos_import.py
@@ -117,6 +117,16 @@ options:
         description:
             - When I(category=idp-metadata), the name of the SAML profile to create.
         type: str
+    template:
+        description:
+            - (Panorama only) The template this operation should target.
+              Mutually exclusive with I(template_stack).
+        type: str
+    template_stack:
+        description:
+            - (Panorama only) The template stack this operation should target.
+              Mutually exclusive with I(template).
+        type: str
     url:
         description:
             - URL of the file that will be imported to device.
@@ -170,6 +180,14 @@ EXAMPLES = """
     category: 'idp-metadata'
     filename: '/tmp/saml_metadata.xml'
     profile_name: 'saml-profile'
+
+- name: Import SAML metadata profile to template
+  panos_import:
+    provider: '{{ device }}'
+    category: 'idp-metadata'
+    filename: '/tmp/saml_metadata.xml'
+    profile_name: 'saml-profile'
+    template: firewall-template
 """
 
 RETURN = """
@@ -227,6 +245,8 @@ def main():
     helper = get_connection(
         with_classic_provider_spec=True,
         argument_spec=dict(
+            template=dict(type="str"),
+            template_stack=dict(type="str"),
             category=dict(
                 type="str",
                 choices=[
@@ -325,6 +345,12 @@ def main():
 
     elif category == "idp-metadata":
         params["profile-name"] = module.params["profile_name"]
+
+    if module.params["template_stack"] is not None:
+        params["target-tpl"] = module.params["template_stack"]
+
+    elif module.params["template"] is not None:
+        params["target-tpl"] = module.params["template"]
 
     try:
         if not module.check_mode:

--- a/plugins/modules/panos_import.py
+++ b/plugins/modules/panos_import.py
@@ -36,6 +36,7 @@ requirements:
     - requests_toolbelt
 extends_documentation_fragment:
     - paloaltonetworks.panos.fragments.transitional_provider
+    - paloaltonetworks.panos.fragments.full_template_support
 options:
     category:
         description:
@@ -116,16 +117,6 @@ options:
     profile_name:
         description:
             - When I(category=idp-metadata), the name of the SAML profile to create.
-        type: str
-    template:
-        description:
-            - (Panorama only) The template this operation should target.
-              Mutually exclusive with I(template_stack).
-        type: str
-    template_stack:
-        description:
-            - (Panorama only) The template stack this operation should target.
-              Mutually exclusive with I(template).
         type: str
     url:
         description:

--- a/plugins/modules/panos_import.py
+++ b/plugins/modules/panos_import.py
@@ -243,10 +243,11 @@ def delete_file(path):
 
 def main():
     helper = get_connection(
+        template=True,
+        template_stack=True,
+        template_is_optional=True,
         with_classic_provider_spec=True,
         argument_spec=dict(
-            template=dict(type="str"),
-            template_stack=dict(type="str"),
             category=dict(
                 type="str",
                 choices=[

--- a/plugins/modules/panos_import.py
+++ b/plugins/modules/panos_import.py
@@ -324,8 +324,11 @@ def main():
 
     url = module.params["url"]
 
+    # get_pandevice_parent will validate templates. The returned value, if a template, is not useable.
     parent = helper.get_pandevice_parent(module)
-    xapi = parent.xapi
+    xapi = (
+        helper.device.xapi
+    )  # This is why we get the xapi info from helper.device instead
 
     changed = False
 


### PR DESCRIPTION
Allowing the users to import files to template(_stack)s

## Description

Added template and template_stacks as parameters for the panos_import module. 

- I had to get the xapi object from helper.device.xapi instead of the parent.xapi since calling get_pandevice_parent with a template only returns the template name, but I had to keep the call to get_pandevice_parent to validate template/template_stack existing or not. If the template does not exist the API will create a new template which is not the intended behavior on my side. 
- If there's a better way to solve the above I'm more than happy to update it.

[Link to where i found the target-tpl parameter](https://docs.paloaltonetworks.com/pan-os/10-0/pan-os-panorama-api/pan-os-xml-api-use-cases/manage-certificates-api.html)

## Motivation and Context

This change helps me manage SAML via Panorama and template on firewalls.
No open issue as far as I can see.

## How Has This Been Tested?

- Tested that import_panos worked without giving a template/template_stack by uploading certs and a saml config.
- Tested that I could import to a template.
- Tested that I could import to a template_stack.
- Tested that if given a template name to template_stack it will error and vice versa.
- Tested that the module gave an error if the template did not exist.

Tested on 9.1.8 but documentation has not changed for other versions so should be fine.



## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist

- [ x ] I have updated the documentation accordingly.
- [ x ] I have read the **CONTRIBUTING** document.
- [ x ] I have added tests to cover my changes if appropriate.
- [ x ] All new and existing tests passed.
