### PR TITLE
docs(panos_security_rule): Clarified `source_ip` and `destination_ip`

### DIFF
--- a/plugins/modules/panos_security_rule.py
+++ b/plugins/modules/panos_security_rule.py
@@ -60,6 +60,7 @@ options:
     source_ip:
         description:
             - List of source addresses.
+            - This can be an IP address, an address object/group, etc.
         default: ["any"]
         type: list
         elements: str
@@ -86,6 +87,7 @@ options:
     destination_ip:
         description:
             - List of destination addresses.
+            - This can be an IP address, an address object/group, etc.
         default: ["any"]
         type: list
         elements: str


### PR DESCRIPTION
fixes #260
