### PR TITLE
Fix wrong variable name on panos_admpwd example

### DIFF
--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -139,7 +139,7 @@ used in particular when NGFW is deployed in the cloud (such as AWS).
   - name: Change user password using ssh protocol
     panos_admpwd:
       ip_address: '{{ ip_address }}'
-      password: '{{ password }}'
+      username: '{{ username }}'
       newpassword: '{{ new_password }}'
       key_filename: '{{ key_filename }}'
 


### PR DESCRIPTION
## Description

The panos_admpwd documentation showed `password` instead of the actual variable, `username`.

## Motivation and Context

This straightens out any confusion one would have when reading the docs.

## How Has This Been Tested?

NA

## Types of changes

NA

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
