### PR TITLE
Bugfix panos_nat_rule.py dnat_dynamic_address

### DIFF
--- a/plugins/modules/panos_nat_rule.py
+++ b/plugins/modules/panos_nat_rule.py
@@ -455,6 +455,9 @@ def main():
     snat_bidirectional = module.params["snat_bidirectional"]
     dnat_address = module.params["dnat_address"]
     dnat_port = module.params["dnat_port"]
+    dnat_dynamic_address = module.params["dnat_dynamic_address"]
+    dnat_dynamic_port=module.params["dnat_dynamic_port"]
+    dnat_dynamic_distribution=module.params["dnat_dynamic_distribution"]
 
     # Get other info.
     state = module.params["state"]
@@ -496,6 +499,9 @@ def main():
         snat_bidirectional=snat_bidirectional,
         dnat_address=dnat_address,
         dnat_port=dnat_port,
+        dnat_dynamic_address=dnat_dynamic_address,
+        dnat_dynamic_port=dnat_dynamic_port,
+        dnat_dynamic_distribution=dnat_dynamic_distribution,
         target=target,
         negate_target=negate_target,
         group_tag=module.params["group_tag"],

--- a/plugins/modules/panos_nat_rule.py
+++ b/plugins/modules/panos_nat_rule.py
@@ -456,8 +456,8 @@ def main():
     dnat_address = module.params["dnat_address"]
     dnat_port = module.params["dnat_port"]
     dnat_dynamic_address = module.params["dnat_dynamic_address"]
-    dnat_dynamic_port=module.params["dnat_dynamic_port"]
-    dnat_dynamic_distribution=module.params["dnat_dynamic_distribution"]
+    dnat_dynamic_port = module.params["dnat_dynamic_port"]
+    dnat_dynamic_distribution = module.params["dnat_dynamic_distribution"]
 
     # Get other info.
     state = module.params["state"]


### PR DESCRIPTION
## Description

After upgrading to version 2.8.0 my panos_nat_rule no longer worked. I was getting a key error, see below, 

Error: 
```JSON
"module_stderr": "ansible_collections/paloaltonetworks/panos/plugins/modules/panos_nat_rule.py\", line 339, in create_nat_rule\nKeyError: 'dnat_dynamic_address'\n", "module_stdout": "", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1} 
```  

I have corrected this by adding the below to the objects and parsing those params into the function call so create_nat_rule will no longer throw an error when those parameters are not supplied.

- dnat_dynamic_address
- dnat_dynamic_port
- dnat_dynamic_distribution


## Motivation and Context


The change is required because it breaks anything not using the dnat_dynamic_address.

Haven't opened an issue - I wanted to see if I could fix it myself before doing so.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
