### PR TITLE
Improve minimum package error message

### DIFF
--- a/plugins/module_utils/panos.py
+++ b/plugins/module_utils/panos.py
@@ -139,12 +139,12 @@ class ConnectionHelper(object):
                 " ".join(lum), version="3.0.0", collection_name="paloaltonetworks.panos"
             )
 
-        # Verify pandevice minimum version.
+        # Verify pan-os-python (formerly pandevice) minimum version.
         if self.min_pandevice_version is not None:
             if pdv < self.min_pandevice_version:
                 module.fail_json(
                     msg=_MIN_VERSION_ERROR.format(
-                        "panos", panos.__version__, _vstr(self.min_pandevice_version)
+                        "pan-os-python", panos.__version__, _vstr(self.min_pandevice_version)
                     )
                 )
 

--- a/plugins/module_utils/panos.py
+++ b/plugins/module_utils/panos.py
@@ -144,7 +144,9 @@ class ConnectionHelper(object):
             if pdv < self.min_pandevice_version:
                 module.fail_json(
                     msg=_MIN_VERSION_ERROR.format(
-                        "pan-os-python", panos.__version__, _vstr(self.min_pandevice_version)
+                        "pan-os-python",
+                        panos.__version__,
+                        _vstr(self.min_pandevice_version),
                     )
                 )
 


### PR DESCRIPTION
## Description
Change error message and update comment in code for pandevice/pan-os-python minimum version

## Motivation and Context
Current error message states "panos version < minimum" which infers PAN-OS version on firewall/Panorama is below minimum. What is really meant is that the pan-os-python package is not at the minimum version, not the PAN-OS devices.

## How Has This Been Tested?
Single string update, tested locally

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
