### PR TITLE
Fix wrong variable name on panos_admpwd example

### DIFF
--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -139,7 +139,7 @@ used in particular when NGFW is deployed in the cloud (such as AWS).
   - name: Change user password using ssh protocol
     panos_admpwd:
       ip_address: '{{ ip_address }}'
-      password: '{{ password }}'
+      username: '{{ username }}'
       newpassword: '{{ new_password }}'
       key_filename: '{{ key_filename }}'
 


### PR DESCRIPTION
## Description

This fixes a typo in the docs that can cause confusion on how to use the panos_admpwd module.

## Motivation and Context

This solves any confusion brought about by the panos_admpwd module example.

## How Has This Been Tested?

NA

## Screenshots (if appropriate)

NA

## Types of changes

Document update

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
