### PR TITLE
Adding UUID to panos_security_rule to align with python modules and r…

### DIFF
--- a/plugins/modules/panos_security_rule.py
+++ b/plugins/modules/panos_security_rule.py
@@ -250,7 +250,7 @@ options:
         description:
             - Add an audit comment to the rule being defined.
         type: str
-   uuid:
+    uuid:
         description:
             - The UUID for this rule.     
     group_tag:

--- a/plugins/modules/panos_security_rule.py
+++ b/plugins/modules/panos_security_rule.py
@@ -250,6 +250,9 @@ options:
         description:
             - Add an audit comment to the rule being defined.
         type: str
+   uuid:
+        description:
+            - The UUID for this rule.     
     group_tag:
         description:
             - The group tag.
@@ -423,6 +426,7 @@ def main():
             commit=dict(type="bool", default=False),
             audit_comment=dict(type="str"),
             group_tag=dict(),
+            uuid=dict(),
             # TODO(gfreeman) - remove this in the next role release.
             devicegroup=dict(),
         ),
@@ -489,6 +493,7 @@ def main():
         "target": module.params["target"],
         "negate_target": module.params["negate_target"],
         "group_tag": module.params["group_tag"],
+        "uuid": module.params["uuid"],
     }
 
     # Other module info.


### PR DESCRIPTION
…eturned values when comparing if a rule is changed

## Description

Added uuid to panos_security_rule

## Motivation and Context

To align with options in python modules and returned result this will avoid having rules registered as changed
https://github.com/PaloAltoNetworks/pan-os-ansible/issues/310#issue-1225582330

## How Has This Been Tested?
Using firewall rule:
```
  tasks:
    # permit dns to 1.1.1.1
    - name: permit dns to 1.1.1.1
      panos_security_rule:
        provider: "{{ panorama_provider }}"
        device_group: "{{ dg | default('Test') }}"
        rule_name: 'ansible-test-dns-permit'
        description: 'DNS rule test'
        source_zone: ['any']
        destination_zone: ['internet']
        source_ip: ['any']
        source_user: ['any']
        destination_ip: ['1.1.1.1']
        category: ['any']
        application: ['dns']
        service: ['application-default']
        action: 'allow'
        state: 'present'
        commit: false
        uuid: '544ee9f1-759d-4194-bb08-ca1f02669ffa'
´´´

Tested directly towards: 
Panorama 10.0.9
Firewall 8.1.7
Firewall 9.1.10

## Screenshots (if appropriate)


## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
