### PR TITLE
[ISSUE-305]  Updated dependencies

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -47,7 +47,8 @@ tags:
 # collection label 'namespace.name'. The value is a version range
 # L(specifiers,https://python-semanticversion.readthedocs.io/en/latest/#requirement-specification). Multiple version
 # range specifiers can be set and are separated by ','
-dependencies: {}
+dependencies:
+  pan-os-python: '>=1.7.2'
 
 # The URL of the originating SCM repository
 repository: 'https://github.com/PaloAltoNetworks/pan-os-ansible'

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -48,7 +48,7 @@ tags:
 # L(specifiers,https://python-semanticversion.readthedocs.io/en/latest/#requirement-specification). Multiple version
 # range specifiers can be set and are separated by ','
 dependencies:
-  pan-os-python: '>=1.7.2'
+    'pan-os-python': '>=1.7.2'
 
 # The URL of the originating SCM repository
 repository: 'https://github.com/PaloAltoNetworks/pan-os-ansible'


### PR DESCRIPTION
ISSUE-305 was resolved / addressed in pan-os-python v1.7.2.  Added the
dependency into galaxy.yml to ensure that a version that fixes the issue
gets installed with our collection.

## Description

Added a dependency to make sure that a version of pan-os-python gets installed that corrects the issue for the change in security rules' hip profiles behavior between certain versions of PanOS.

## Motivation and Context

This change addresses [ISSUE-305](https://github.com/PaloAltoNetworks/pan-os-ansible/issues/305)

## How Has This Been Tested?

installed pan-os-python 1.7.2 using pip install and confirmed that security rules now create just fine on 10.1.15.

- [ X ] I have updated the documentation accordingly.
- [ X ] I have read the **CONTRIBUTING** document.
- [ X ] I have added tests to cover my changes if appropriate.
- [ X ] All new and existing tests passed.
