### PR TITLE
[ISSUE-310]  Added ignore for uuids in security group rules

### DIFF
--- a/plugins/module_utils/panos.py
+++ b/plugins/module_utils/panos.py
@@ -407,6 +407,7 @@ class ConnectionHelper(object):
         module=None,
         enabled_disabled_param=None,
         invert_enabled_disabled=False,
+        ignore_uuid=False,
     ):
         """Generic state handling.
 
@@ -425,6 +426,8 @@ class ConnectionHelper(object):
             invert_enabled_disabled (bool): Set this to True if the param
                 specified in "enabled_disabled_param" is a disabled flag
                 instead of an enabled flag.
+            ignore_uuid (bool): Set this to False if we should ignore
+                the uuid field when comparing the old and new objects
 
         Returns:
             bool: If a change was made or not.
@@ -476,6 +479,9 @@ class ConnectionHelper(object):
             for item in listing:
                 if item.uid != obj.uid:
                     continue
+                temp_uuid = None
+                if ignore_uuid:
+                    temp_uuid, item.uuid = item.uuid, None
                 diff = dict(before=eltostr(item))
                 obj_child_types = [x.__class__ for x in obj.children]
                 other_children = []
@@ -493,6 +499,8 @@ class ConnectionHelper(object):
                             obj.apply()
                         except PanDeviceError as e:
                             module.fail_json(msg="Failed apply: {0}".format(e))
+                if ignore_uuid:
+                    item.uuid = temp_uuid
                 break
             else:
                 changed = True

--- a/plugins/modules/panos_security_rule.py
+++ b/plugins/modules/panos_security_rule.py
@@ -508,7 +508,7 @@ def main():
     parent.add(new_rule)
 
     # Which action shall we take on the rule object?
-    changed, diff = helper.apply_state(new_rule, rules, module)
+    changed, diff = helper.apply_state(new_rule, rules, module, ignore_uuid=True)
 
     # Move the rule to the correct spot, if applicable.
     if module.params["state"] == "present":


### PR DESCRIPTION
## Description

Added an `ignore_uuid` flag to the `apply_state` helper so that we would
be able to selectively ignore the uuid for certain objects, like
security group rules, where we don't yet support uuid as a parameter.

## Motivation and Context

The uuid returned from an existing rule was causing all security
rules to show as if they had changes even when no changes to the rules
would be made.  

This change addresses [ISSUE-310](https://github.com/PaloAltoNetworks/pan-os-ansible/issues/310)

## How Has This Been Tested?

Used the updated module to rerun existing playbooks with security group rules and confirmed that no changes were reported after running the playbooks.

- [ X ] I have updated the documentation accordingly.
- [ X ] I have read the **CONTRIBUTING** document.
- [ X ] I have added tests to cover my changes if appropriate.
- [ X ] All new and existing tests passed.
