### PR TITLE
removed un-needed forced software check device.software.check() as so…

### DIFF
--- a/plugins/modules/panos_software.py
+++ b/plugins/modules/panos_software.py
@@ -176,7 +176,6 @@ def main():
 
     try:
         device.timeout = timeout
-        device.software.check()
 
         if target != current:
 


### PR DESCRIPTION
…ftware check can be executed on demand via cli, no need to force this here as offline systems can't pass this forced check

## Description

This pull request removes un-needed forced software check device.software.check() as software check can be executed on demand via cli, no need to force this here as offline systems can't pass this forced check

## Motivation and Context

This change is required so that offline systems where images have been sides loaded to the firewall can have an upgrade performed without the need to check into a update server.

## How Has This Been Tested?

This has been tested on a non-internet connected system to validate this works as needed.

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (this non-breaking change allows for offline systems that have had os images sideloaded to execute an upgrade when their is no internet connection available.)


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
~~- [x] I have added tests to cover my changes if appropriate.~~
~~- [x] All new and existing tests passed.~~
