### PR TITLE
Allow downgrade in panos_software.py

### DIFF
--- a/plugins/modules/panos_software.py
+++ b/plugins/modules/panos_software.py
@@ -128,7 +128,7 @@ def needs_download(device, version):
     return not device.software.versions[str(version)]["downloaded"]
 
 
-def is_valid_upgrade(current, target):
+def is_valid_sequence(current, target):
     # Patch version upgrade (major and minor versions match)
     if (current.major == target.major) and (current.minor == target.minor):
         return True
@@ -141,6 +141,14 @@ def is_valid_upgrade(current, target):
     elif (current.major + 1 == target.major) and (target.minor == 0):
         return True
 
+    # Downgrade minor version (9.1.0 -> 9.0.0)
+    elif (current.major == target.major) and (current.minor - 1 == target.minor):
+        return True
+    
+    # Downgrade major version (10.2.0 -> 10.1.0)
+    elif (current.major - 1 == target.major) and (target.minor == 0):
+        return True
+    
     else:
         return False
 
@@ -187,9 +195,9 @@ def main():
 
         if target != current:
 
-            if not is_valid_upgrade(current, target):
+            if not is_valid_sequence(current, target):
                 module.fail_json(
-                    msg="Upgrade is invalid: {0} -> {1}".format(current, target)
+                    msg="Version Sequence is invalid: {0} -> {1}".format(current, target)
                 )
 
             # Download new base version if needed.

--- a/plugins/modules/panos_software.py
+++ b/plugins/modules/panos_software.py
@@ -144,11 +144,11 @@ def is_valid_sequence(current, target):
     # Downgrade minor version (9.1.0 -> 9.0.0)
     elif (current.major == target.major) and (current.minor - 1 == target.minor):
         return True
-    
+
     # Downgrade major version (10.2.0 -> 10.1.0)
     elif (current.major - 1 == target.major) and (target.minor == 0):
         return True
-    
+
     else:
         return False
 
@@ -197,7 +197,9 @@ def main():
 
             if not is_valid_sequence(current, target):
                 module.fail_json(
-                    msg="Version Sequence is invalid: {0} -> {1}".format(current, target)
+                    msg="Version Sequence is invalid: {0} -> {1}".format(
+                        current, target
+                    )
                 )
 
             # Download new base version if needed.

--- a/plugins/modules/panos_software.py
+++ b/plugins/modules/panos_software.py
@@ -145,8 +145,8 @@ def is_valid_sequence(current, target):
     elif (current.major == target.major) and (current.minor - 1 == target.minor):
         return True
 
-    # Downgrade major version (10.2.0 -> 10.1.0)
-    elif (current.major - 1 == target.major) and (target.minor == 0):
+    # Downgrade major version (10.0.3 -> 9.1.6)
+    elif current.major - 1 == target.major:
         return True
 
     else:


### PR DESCRIPTION
allow panos_software to perform downgrades in addition to upgrades

## Description

panos_software no longer allows the user to perform a software downgrade. This patch allows a downgrade operation by verifying the version sequence. I.e. 1 minor or major step at a time.

## Motivation and Context

Downgrades are a requirement that should be supported. If an upgrade fails for some reason, we should be able to use panos_software to rollback.

## How Has This Been Tested?

Use panos_software module with a desired version less than the current version

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

simple logic to check if desired_version is less than current version by no more than 1 


- Bug fix (non-breaking change which fixes an issue)

Not being able to downgrade is a bug that was introduced some time ago.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
