### PR TITLE
Adds conditional for address_prefix

### DIFF
--- a/plugins/modules/panos_bgp_policy_rule.py
+++ b/plugins/modules/panos_bgp_policy_rule.py
@@ -375,16 +375,20 @@ def main():
     else:
         obj = BgpPolicyExportRule(**spec)
 
-    # Handle address prefixes.
-    for x in module.params["address_prefix"]:
-        if "name" not in x:
-            module.fail_json(msg='Address prefix dict requires "name": {0}'.format(x))
-        obj.add(
-            BgpPolicyAddressPrefix(
-                to_text(x["name"], encoding="utf-8", errors="surrogate_or_strict"),
-                None if x.get("exact") is None else module.boolean(x["exact"]),
+    # Since address_prefix can legitimately be empty, only process it if non-empty
+    if module.params["address_prefix"] is not None:
+        # Handle address prefixes.
+        for x in module.params["address_prefix"]:
+            if "name" not in x:
+                module.fail_json(
+                    msg='Address prefix dict requires "name": {0}'.format(x)
+                )
+            obj.add(
+                BgpPolicyAddressPrefix(
+                    to_text(x["name"], encoding="utf-8", errors="surrogate_or_strict"),
+                    None if x.get("exact") is None else module.boolean(x["exact"]),
+                )
             )
-        )
 
     listing = bgp.findall(obj.__class__)
     bgp.add(obj)


### PR DESCRIPTION
## Description

Adding conditional check for address_prefix to check it is populated

## Motivation and Context

Whilst PAN-OS and and pan-os-ansible both agree it is optional, the code runs a loop that assumes a value will be present, and when there has been no value specified for address_prefix in the user's playbook, the execution fails because the for loop can't run on an empty value

## How Has This Been Tested?

Problem found during lab testing. Code change tested on local machine per method described in the contributing guide.

I attempted to run `ansible-test sanity --local` per the contributing guide, but after battling various challenges of python versions, package dependencies, pyenvs, and stuff not installing during the execution of the  `ansible-test sanity --local`, I gave up, sorry.

## Screenshots (if appropriate)

Before and after screenshot:
![Screenshot 2022-09-15 at 18 43 50](https://user-images.githubusercontent.com/6574404/190494430-638a46d4-7025-4f39-92d2-f9c271a8e641.png)

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
