### PR TITLE
Add AutomationHub publishing alongside Galaxy

### DIFF
--- a/.github/do-release.sh
+++ b/.github/do-release.sh
@@ -2,3 +2,4 @@
 
 ansible-galaxy collection build
 ansible-galaxy collection publish paloaltonetworks-panos-*
+ansible-galaxy collection publish --server https://console.redhat.com/api/automation-hub/content/inbound-paloaltonetworks/ paloaltonetworks-panos-*


### PR DESCRIPTION
## Description
Adding extra step to publishing workflow, which will upload the collection to Automation Hub

## Motivation and Context
Publishing to Automation Hub is part of becoming certified, and we are required to dual publish, both to the original Galaxy but also to Automation Hub as well.

## How Has This Been Tested?
Tested via Automation Hub (unable to test CLI at the moment due to API key)

## Screenshots (if appropriate)
N/A

## Types of changes
- New feature (non-breaking change which adds functionality)

## Checklist
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.