### PR TITLE
fix(panos_export): Fix: export_async

### DIFF
--- a/plugins/modules/panos_export.py
+++ b/plugins/modules/panos_export.py
@@ -280,7 +280,20 @@ def export_async(module, xapi, category, filename, interval=60, timeout=600):
 
     # Get completed job
     xapi.export(category=category, extra_qs={"action": "get", "job-id": job_id})
-    export_binary(module, xapi, filename)
+
+    # Use only relevant code from export_binary, instead of calling export_binary (don't use the line: xapi.export(category=category))
+    f = None
+
+    try:
+        with open(filename, "wb") as f:
+            content = xapi.export_result["content"]
+
+            if content is not None:
+                f.write(content)
+
+            f.close()
+    except IOError as msg:
+        module.fail_json(msg=msg)
 
 
 HTML_EXPORTS = [


### PR DESCRIPTION
## Description
Fix for exporting tech-support and stats-dump files.

## Motivation and Context
Looking to fix #359.
This issue appears to have been present since the 2.6.0 release.

Per #359, exporting tech-support and stats-dump files were failing because since 2.6.0, export_binary function needs a category value.
- The existing call of export_binary from within export_async: `export_binary(module, xapi, filename)`
- The error produced:
```
TASK [Download Stats Dump File] ***********************************************************************************************************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: TypeError: export_binary() missing 1 required positional argument: 'filename'
fatal: [firewall]: FAILED! => {"changed": false, "module_stderr": "Traceback (most recent call last):\n  File \"/Users/jholland/.ansible/tmp/ansible-tmp-1669396692.813608-25249-86302958496394/AnsiballZ_panos_export.py\", line 107, in <module>\n    _ansiballz_main()\n  File \"/Users/jholland/.ansible/tmp/ansible-tmp-1669396692.813608-25249-86302958496394/AnsiballZ_panos_export.py\", line 99, in _ansiballz_main\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\n  File \"/Users/jholland/.ansible/tmp/ansible-tmp-1669396692.813608-25249-86302958496394/AnsiballZ_panos_export.py\", line 47, in invoke_module\n    runpy.run_module(mod_name='ansible_collections.paloaltonetworks.panos.plugins.modules.panos_export', init_globals=dict(_module_fqn='ansible_collections.paloaltonetworks.panos.plugins.modules.panos_export', _modlib_path=modlib_path),\n  File \"/Users/jholland/.pyenv/versions/3.10.4/lib/python3.10/runpy.py\", line 209, in run_module\n    return _run_module_code(code, init_globals, run_name, mod_spec)\n  File \"/Users/jholland/.pyenv/versions/3.10.4/lib/python3.10/runpy.py\", line 96, in _run_module_code\n    _run_code(code, mod_globals, init_globals,\n  File \"/Users/jholland/.pyenv/versions/3.10.4/lib/python3.10/runpy.py\", line 86, in _run_code\n    exec(code, run_globals)\n  File \"/var/folders/5k/v6w2wvm92sg_drdh0rw6p74w0000gp/T/ansible_paloaltonetworks.panos.panos_export_payload_6dw0a0xg/ansible_paloaltonetworks.panos.panos_export_payload.zip/ansible_collections/paloaltonetworks/panos/plugins/modules/panos_export.py\", line 504, in <module>\n  File \"/var/folders/5k/v6w2wvm92sg_drdh0rw6p74w0000gp/T/ansible_paloaltonetworks.panos.panos_export_payload_6dw0a0xg/ansible_paloaltonetworks.panos.panos_export_payload.zip/ansible_collections/paloaltonetworks/panos/plugins/modules/panos_export.py\", line 375, in main\n  File \"/var/folders/5k/v6w2wvm92sg_drdh0rw6p74w0000gp/T/ansible_paloaltonetworks.panos.panos_export_payload_6dw0a0xg/ansible_paloaltonetworks.panos.panos_export_payload.zip/ansible_collections/paloaltonetworks/panos/plugins/modules/panos_export.py\", line 283, in export_async\nTypeError: export_binary() missing 1 required positional argument: 'filename'\n", "module_stdout": "", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1}
```

I tried passing in the missing category value at line 283, but this also failed. This was because since 2.6.0, export_binary does a call to xapi.export (currently line 241) effectively duplicating the xapi.export call already done (currently in line 283) within export_async. This duplicate call to xapi.export in export_binary does not use the job id, leading to an empty xapi.export_result
- The attempted first fix: `export_binary(module, xapi, category, filename)`
- The error produced:
```
TASK [Download Stats Dump File] ***********************************************************************************************************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: TypeError: 'NoneType' object is not subscriptable
fatal: [firewall]: FAILED! => {"changed": false, "module_stderr": "Traceback (most recent call last):\n  File \"/Users/jholland/.ansible/tmp/ansible-tmp-1669396771.987699-25425-194357986131475/AnsiballZ_panos_export.py\", line 107, in <module>\n    _ansiballz_main()\n  File \"/Users/jholland/.ansible/tmp/ansible-tmp-1669396771.987699-25425-194357986131475/AnsiballZ_panos_export.py\", line 99, in _ansiballz_main\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\n  File \"/Users/jholland/.ansible/tmp/ansible-tmp-1669396771.987699-25425-194357986131475/AnsiballZ_panos_export.py\", line 47, in invoke_module\n    runpy.run_module(mod_name='ansible_collections.paloaltonetworks.panos.plugins.modules.panos_export', init_globals=dict(_module_fqn='ansible_collections.paloaltonetworks.panos.plugins.modules.panos_export', _modlib_path=modlib_path),\n  File \"/Users/jholland/.pyenv/versions/3.10.4/lib/python3.10/runpy.py\", line 209, in run_module\n    return _run_module_code(code, init_globals, run_name, mod_spec)\n  File \"/Users/jholland/.pyenv/versions/3.10.4/lib/python3.10/runpy.py\", line 96, in _run_module_code\n    _run_code(code, mod_globals, init_globals,\n  File \"/Users/jholland/.pyenv/versions/3.10.4/lib/python3.10/runpy.py\", line 86, in _run_code\n    exec(code, run_globals)\n  File \"/var/folders/5k/v6w2wvm92sg_drdh0rw6p74w0000gp/T/ansible_paloaltonetworks.panos.panos_export_payload_dswfye6s/ansible_paloaltonetworks.panos.panos_export_payload.zip/ansible_collections/paloaltonetworks/panos/plugins/modules/panos_export.py\", line 504, in <module>\n  File \"/var/folders/5k/v6w2wvm92sg_drdh0rw6p74w0000gp/T/ansible_paloaltonetworks.panos.panos_export_payload_dswfye6s/ansible_paloaltonetworks.panos.panos_export_payload.zip/ansible_collections/paloaltonetworks/panos/plugins/modules/panos_export.py\", line 375, in main\n  File \"/var/folders/5k/v6w2wvm92sg_drdh0rw6p74w0000gp/T/ansible_paloaltonetworks.panos.panos_export_payload_dswfye6s/ansible_paloaltonetworks.panos.panos_export_payload.zip/ansible_collections/paloaltonetworks/panos/plugins/modules/panos_export.py\", line 283, in export_async\n  File \"/var/folders/5k/v6w2wvm92sg_drdh0rw6p74w0000gp/T/ansible_paloaltonetworks.panos.panos_export_payload_dswfye6s/ansible_paloaltonetworks.panos.panos_export_payload.zip/ansible_collections/paloaltonetworks/panos/plugins/modules/panos_export.py\", line 245, in export_binary\nTypeError: 'NoneType' object is not subscriptable\n", "module_stdout": "", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1}
```

Therefore, the last attempt I made was to not call export_binary from within export_async, but copy the code from export binary, as at the 2.5.0 version and without the xapi.export call.
- The success:
```
TASK [Download Stats Dump File] ***********************************************************************************************************************************
ok: [firewall]

TASK [Download Device-state File] *********************************************************************************************************************************
ok: [firewall]

TASK [Download Tech support] **************************************************************************************************************************************
ok: [firewall]
```

I realise this solution is not very DRY, but also I did not want to modify export_binary because it looks like lots of other functions call that function and I was not confident in fully testing those scenarios. @shinmog - you may wish to look for a better solution, I will leave that decision to you :-) 

## How Has This Been Tested?
I tested locally on my machine with this:
```yaml
  tasks:
    - name: Download Stats Dump File
      paloaltonetworks.panos.panos_export:
        provider: "{{ device }}"
        category: "stats-dump"
        filename: "statsdump.tar.gz"

    - name: Download Device-state File
      paloaltonetworks.panos.panos_export:
        provider: "{{ device }}"
        category: "device-state"
        filename: "device-state.tgz"

    - name: Download Tech support
      paloaltonetworks.panos.panos_export:
        provider: "{{ device }}"
        category: "tech-support"
        filename: "tech-support.tgz"
```
I install 2.5.0, and the device-state task fails. 2.6.0 and above fixes device-state, but breaks the other two tasks. The code in this PR results in all three tasks succeeding.

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate - N/A
- [x] All new and existing tests passed.