### PR TITLE
Refresh device version before accessing attribute

### DIFF
--- a/plugins/modules/panos_software.py
+++ b/plugins/modules/panos_software.py
@@ -184,6 +184,7 @@ def main():
     restart = module.params["restart"]
     timeout = module.params["timeout"]
 
+    device.refresh_version()
     current = PanOSVersion(device.version)
 
     changed = False


### PR DESCRIPTION
## Description

One line added to refresh the device's version before attempting to access it in `panos_software.py`.

## Motivation and Context

Was getting the following error when trying to use the `panos_software` module,

```
/var/folders/sb/wzby_gw52ybcdk_xzvfnmg2w0000gp/T/ansible_paloaltonetworks.panos.panos_software_payload_ia1b1v9h/ansible_paloaltonetworks.panos.panos_software_payload.zip/ansible_collections/paloaltonetworks/panos/plugins/modules/panos_software.py:172: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
/var/folders/sb/wzby_gw52ybcdk_xzvfnmg2w0000gp/T/ansible_paloaltonetworks.panos.panos_software_payload_ia1b1v9h/ansible_paloaltonetworks.panos.panos_software_payload.zip/ansible_collections/paloaltonetworks/panos/plugins/modules/panos_software.py:179: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
Traceback (most recent call last):
  File "/Users/XXXXX/.ansible/tmp/ansible-tmp-1670018746.698667-13801-38660490920878/AnsiballZ_panos_software.py", line 107, in <module>
    _ansiballz_main()
  File "/Users/XXXXX/.ansible/tmp/ansible-tmp-1670018746.698667-13801-38660490920878/AnsiballZ_panos_software.py", line 99, in _ansiballz_main
    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)
  File "/Users/XXXXX/.ansible/tmp/ansible-tmp-1670018746.698667-13801-38660490920878/AnsiballZ_panos_software.py", line 47, in invoke_module
    runpy.run_module(mod_name='ansible_collections.paloaltonetworks.panos.plugins.modules.panos_software', init_globals=dict(_module_fqn='ansible_collections.paloaltonetworks.panos.plugins.modules.panos_software', _modlib_path=modlib_path),
  File "/opt/homebrew/Cellar/python@3.10/3.10.6_2/Frameworks/Python.framework/Versions/3.10/lib/python3.10/runpy.py", line 224, in run_module
    return _run_module_code(code, init_globals, run_name, mod_spec)
  File "/opt/homebrew/Cellar/python@3.10/3.10.6_2/Frameworks/Python.framework/Versions/3.10/lib/python3.10/runpy.py", line 96, in _run_module_code
    _run_code(code, mod_globals, init_globals,
  File "/opt/homebrew/Cellar/python@3.10/3.10.6_2/Frameworks/Python.framework/Versions/3.10/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/var/folders/sb/wzby_gw52ybcdk_xzvfnmg2w0000gp/T/ansible_paloaltonetworks.panos.panos_software_payload_ia1b1v9h/ansible_paloaltonetworks.panos.panos_software_payload.zip/ansible_collections/paloaltonetworks/panos/plugins/modules/panos_software.py", line 229, in <module>
  File "/var/folders/sb/wzby_gw52ybcdk_xzvfnmg2w0000gp/T/ansible_paloaltonetworks.panos.panos_software_payload_ia1b1v9h/ansible_paloaltonetworks.panos.panos_software_payload.zip/ansible_collections/paloaltonetworks/panos/plugins/modules/panos_software.py", line 188, in main
  File "/opt/homebrew/lib/python3.10/site-packages/panos/__init__.py", line 223, in __ne__
    return not self.__eq__(other)
  File "/opt/homebrew/lib/python3.10/site-packages/panos/__init__.py", line 212, in __eq__
    if self.mainrelease != other.mainrelease:
  File "/opt/homebrew/lib/python3.10/site-packages/panos/__init__.py", line 151, in mainrelease
    return self.version[0:3]
AttributeError: 'PanOSVersion' object has no attribute 'version'
```

The main issue seems to be line 188 in `panos_software.py`, `current = PanOSVersion(device.version)`. 

`device.version` was returning None, which led to the no-attribute error. Adding in `device.refresh_version()` has resolved this issue.

## How Has This Been Tested?

This has been successfully used in a sandbox environment to upgrade NGFWs from 10.0.9 to 10.1.x on Panorama 10.2.0. Running on M1 MacOS 12.5.1.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
