### PR TITLE
Add per-admin parameter to Panorama push

### DIFF
--- a/plugins/modules/panos_commit_push.py
+++ b/plugins/modules/panos_commit_push.py
@@ -56,7 +56,7 @@ options:
         type: str
     admins:
         description:
-            - Push the configuration made by a specific administrator.
+            - Push the configuration made by a specific administrator. (PAN-OS 10.2+)
         type: list
         elements: str
     include_template:

--- a/plugins/modules/panos_commit_push.py
+++ b/plugins/modules/panos_commit_push.py
@@ -153,7 +153,7 @@ except ImportError:
 
 def main():
     helper = get_connection(
-        min_pandevice_version=(1, 8, 0), # 1.8.0 as of adding per-admin push for PAN-OS 10.2+
+        min_pandevice_version=(1, 8, 0),  # 1.8.0 for per-admin push in PAN-OS 10.2+
         min_panos_version=(8, 0, 0),
         argument_spec=dict(
             style=dict(

--- a/plugins/modules/panos_commit_push.py
+++ b/plugins/modules/panos_commit_push.py
@@ -153,7 +153,7 @@ except ImportError:
 
 def main():
     helper = get_connection(
-        min_pandevice_version=(1, 0, 0),
+        min_pandevice_version=(1, 8, 0), # 1.8.0 as of adding per-admin push for PAN-OS 10.2+
         min_panos_version=(8, 0, 0),
         argument_spec=dict(
             style=dict(

--- a/plugins/modules/panos_commit_push.py
+++ b/plugins/modules/panos_commit_push.py
@@ -22,7 +22,7 @@ __metaclass__ = type
 DOCUMENTATION = """
 ---
 module: panos_commit_push
-short_description: Commit Panorama's candidate configuration.
+short_description: Push running configuration to managed devices.
 description:
     - Module that will push the running Panorama configuration to managed devices.
     - The new configuration will become active immediately.
@@ -54,6 +54,11 @@ options:
         description:
             - A description of the commit.
         type: str
+    admins:
+        description:
+            - Push the configuration made by a specific administrator.
+        type: list
+        elements: str
     include_template:
         description:
             - Include device group reference templates.
@@ -117,6 +122,14 @@ EXAMPLES = """
     - Production Firewalls
     - Staging Firewalls
     - Development Firewalls
+
+- name: push admin-specific changes to a device group
+  panos_commit_push:
+    provider: "{{ credentials }}"
+    style: 'device group'
+    name: 'EMEA_Device_Group'
+    admins:
+      - 'ansible-admin'
 """
 
 RETURN = """
@@ -156,6 +169,7 @@ def main():
             ),
             name=dict(type="str"),
             description=dict(type="str"),
+            admins=dict(type="list", elements="str"),
             include_template=dict(type="bool", default=False),
             force_template_values=dict(type="bool", default=False),
             devices=dict(type="list", elements="str"),
@@ -177,6 +191,7 @@ def main():
         style=module.params["style"],
         name=module.params["name"],
         description=module.params["description"],
+        admins=module.params["admins"],
         include_template=module.params["include_template"],
         force_template_values=module.params["force_template_values"],
         devices=module.params["devices"],


### PR DESCRIPTION
## Description
Adding support for the [PAN-OS 10.2 feature](https://docs.paloaltonetworks.com/pan-os/10-2/pan-os-release-notes/features-introduced-in-pan-os/panorama-features) of Administrator-Level Push from Panorama to Managed Devices

Depends upon [supporting change in pan-os-python](https://github.com/PaloAltoNetworks/pan-os-python/pull/485).

## Motivation and Context
Motivation is adding support for a new PAN-OS feature, and also to support adding this feature in pan-os-ansible ([ref - will close this issue](https://github.com/PaloAltoNetworks/pan-os-ansible/issues/361))

## How Has This Been Tested?
Tested locally, with Panorama 11.0.0 and managed firewall 10.2.3
```
  tasks:
    - name: Commit and Push template configuration
      panos_commit_push:
        provider: "{{ device }}"
        style: "device group"
        name: "poc-dg"
        admins:
          - "other"
        include_template: no
        force_template_values: no
      register: results
    - debug:
        msg: "Job ID: {{ results.jobid }} finished"
```

## Screenshots (if appropriate)
![Screenshot 2022-12-22 at 13 44 56](https://user-images.githubusercontent.com/6574404/209147633-fd1d1125-4783-4399-a022-5ad8bdaadee0.png)

## Types of changes
- New feature (non-breaking change which adds functionality)

## Checklist
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.