### PR TITLE
Adds clarification on use case for force-true on panos_lic

### DIFF
--- a/plugins/modules/panos_lic.py
+++ b/plugins/modules/panos_lic.py
@@ -46,7 +46,7 @@ options:
     force:
         description:
             - Whether to apply authcode even if device is already licensed / has a serial number.
-            - For example, use "force: true" when adding extra subscription or features licenses to a device which already has a serial number.
+            - For example, use force: true when adding extra subscription or features licenses to a device which already has a serial number.
         type: bool
         default: False
 """

--- a/plugins/modules/panos_lic.py
+++ b/plugins/modules/panos_lic.py
@@ -46,6 +46,7 @@ options:
     force:
         description:
             - Whether to apply authcode even if device is already licensed / has a serial number.
+            - For example, use "force: true" when adding extra subscription or features licenses to a device which already has a serial number.
         type: bool
         default: False
 """

--- a/plugins/modules/panos_lic.py
+++ b/plugins/modules/panos_lic.py
@@ -46,7 +46,7 @@ options:
     force:
         description:
             - Whether to apply authcode even if device is already licensed / has a serial number.
-            - For example, use force: true when adding extra subscription or features licenses to a device which already has a serial number.
+            - For example, set the force option to "true" when adding extra subscription or features licenses to a device which already has a serial number.
         type: bool
         default: False
 """


### PR DESCRIPTION
## Description
One line of extra docs to clarify a use case

## Motivation and Context
Clarification of the use case came to light after a user question. When using panos_lic, force: true should be used when adding licenses for features/subscriptions to a firewall which already has a serial number (e.g. PA-Series, or licensed VM-Series, etc)

## How Has This Been Tested?
No testing, docs update only

## Screenshots (if appropriate)
N/A

## Types of changes
- One line documentation update

## Checklist
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.