### PR TITLE
ci: Updated CI for push to Galaxy and AutomationHub

### DIFF
--- a/.github/do-release.sh
+++ b/.github/do-release.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
 ansible-galaxy collection build
-ansible-galaxy collection publish paloaltonetworks-panos-*
-ansible-galaxy collection publish --server https://console.redhat.com/api/automation-hub/content/inbound-paloaltonetworks/ paloaltonetworks-panos-*
+ansible-galaxy collection publish paloaltonetworks-panos-* --server release_galaxy
+ansible-galaxy collection publish paloaltonetworks-panos-* --server automation_hub

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,12 +112,29 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      # This task could be removed once the task below is confirmed working
       - name: Set up Galaxy auth
         run: |
           mkdir -p ~/.ansible
           echo "token: $GALAXY_API_KEY" > ~/.ansible/galaxy_token
         env:
           GALAXY_API_KEY: ${{ secrets.GALAXY_API_KEY }}
+        shell: bash
+
+      # New task for combined Galaxy and AutomationHub publishing
+      - name: Set up Automation Hub and Galaxy ansible.cfg file
+        run: |
+          cat << EOF > ansible.cfg
+          [galaxy]
+          server_list = automation_hub, release_galaxy
+          [galaxy_server.automation_hub]
+          url=${{ secrets.AUTOMATION_HUB_URL }}
+          auth_url=${{ secrets.AUTOMATION_HUB_SSO_URL }}
+          token=${{ secrets.AUTOMATION_HUB_API_TOKEN }}
+          [galaxy_server.release_galaxy]
+          url=https://galaxy.ansible.com/
+          token=${{ secrets.GALAXY_API_KEY }}
+          EOF
         shell: bash
 
       - name: Create release and publish


### PR DESCRIPTION
## Description
Updated publishing method for dual publishing to both Galaxy and AutomationHub

## Motivation and Context
Previously AutomationHub publishing was untested, now it is tested

## How Has This Been Tested?
Locally on laptop

## Types of changes
- CI

## Checklist
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.