### PR TITLE
fix(panos_security_rule_facts): params typo

### DIFF
--- a/plugins/modules/panos_security_rule_facts.py
+++ b/plugins/modules/panos_security_rule_facts.py
@@ -335,7 +335,7 @@ def main():
             "rule_name": "name",
             "source_zone": "fromzone",
             "source_ip": "source",
-            "destintaion_zone": "tozone",
+            "destination_zone": "tozone",
             "destination_ip": "destination",
             "rule_type": "type",
             "tag_name": "tag",


### PR DESCRIPTION
## Description
Fix a typo in the params for ```panos_security_rule_facts```

## Motivation and Context
Per https://github.com/PaloAltoNetworks/pan-os-ansible/commit/c671a4160a3911f6c5eca46c2644616e64ae1332#commitcomment-97529680

## How Has This Been Tested?
N/A

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.