### PR TITLE
fix(panos_ipsec_ipv4_proxyid): Fix IPv4 ProxyID proto parameter

### DIFF
--- a/plugins/modules/panos_ipsec_ipv4_proxyid.py
+++ b/plugins/modules/panos_ipsec_ipv4_proxyid.py
@@ -61,12 +61,12 @@ options:
         default: '192.168.1.0/24'
     any_protocol:
         description:
-            - Any protocol boolean
+            - Any protocol boolean. If this parameter is set to `true`, explicitly or implicitly by its default value, the `number_proto` parameter must not be specified.
         type: bool
         default: True
     number_proto:
         description:
-            - Numbered Protocol; protocol number (1-254)
+            - Numbered Protocol; protocol number (1-254). This parameter must be specified if `any_protocol` is set to `false`.
         type: int
     tcp_local_port:
         description:
@@ -121,7 +121,7 @@ def main():
             local=dict(default="192.168.2.0/24"),
             remote=dict(default="192.168.1.0/24"),
             any_protocol=dict(type="bool", default=True),
-            number_proto=dict(type="int"),
+            number_proto=dict(type="int", sdk_param="number_protocol"),
             tcp_local_port=dict(type="int"),
             tcp_remote_port=dict(type="int"),
             udp_local_port=dict(type="int"),

--- a/plugins/modules/panos_ipsec_ipv4_proxyid.py
+++ b/plugins/modules/panos_ipsec_ipv4_proxyid.py
@@ -61,7 +61,7 @@ options:
         default: '192.168.1.0/24'
     any_protocol:
         description:
-            - Any protocol boolean. If this parameter is set to `true`, explicitly or implicitly by its default value, the `number_proto` parameter must not be specified.
+            - Any protocol boolean. If this parameter is set to `true`, the `number_proto` parameter must not be specified.
         type: bool
         default: True
     number_proto:


### PR DESCRIPTION
## Description
Fix IPv4 ProxyID `number_proto` parameter, and also clarify usage in documentation

## Motivation and Context
Fixes #385

## How Has This Been Tested?
Locally

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate - N/A
- [ ] All new and existing tests passed.