### PR TITLE
fix(panos_export): Fix binary exports

### DIFF
--- a/plugins/modules/panos_export.py
+++ b/plugins/modules/panos_export.py
@@ -251,8 +251,9 @@ def export_binary(module, xapi, category, filename):
     except IOError as msg:
         module.fail_json(msg=msg)
 
+
 def save_binary(module, xapi, category, filename):
- 
+
     # This function is almost the same as export_binary, but omits the line...
     #   xapi.export(category=category)
     # This function is therefore used where the xapi.export operation is already done
@@ -269,6 +270,7 @@ def save_binary(module, xapi, category, filename):
             f.close()
     except IOError as msg:
         module.fail_json(msg=msg)
+
 
 def export_async(module, xapi, category, filename, interval=60, timeout=600):
 

--- a/plugins/modules/panos_export.py
+++ b/plugins/modules/panos_export.py
@@ -251,6 +251,24 @@ def export_binary(module, xapi, category, filename):
     except IOError as msg:
         module.fail_json(msg=msg)
 
+def save_binary(module, xapi, category, filename):
+ 
+    # This function is almost the same as export_binary, but omits the line...
+    #   xapi.export(category=category)
+    # This function is therefore used where the xapi.export operation is already done
+
+    f = None
+
+    try:
+        with open(filename, "wb") as f:
+            content = xapi.export_result["content"]
+
+            if content is not None:
+                f.write(content)
+
+            f.close()
+    except IOError as msg:
+        module.fail_json(msg=msg)
 
 def export_async(module, xapi, category, filename, interval=60, timeout=600):
 
@@ -281,19 +299,7 @@ def export_async(module, xapi, category, filename, interval=60, timeout=600):
     # Get completed job
     xapi.export(category=category, extra_qs={"action": "get", "job-id": job_id})
 
-    # Use only relevant code from export_binary, instead of calling export_binary (don't use the line: xapi.export(category=category))
-    f = None
-
-    try:
-        with open(filename, "wb") as f:
-            content = xapi.export_result["content"]
-
-            if content is not None:
-                f.write(content)
-
-            f.close()
-    except IOError as msg:
-        module.fail_json(msg=msg)
+    save_binary(module, xapi, category, filename)
 
 
 HTML_EXPORTS = [
@@ -417,7 +423,7 @@ def main():
             params["passphrase"] = cert_passphrase
 
         xapi.export(category="certificate", extra_qs=params)
-        export_binary(module, xapi, filename)
+        save_binary(module, xapi, category, filename)
 
     elif category == "application-pcap":
 
@@ -439,7 +445,7 @@ def main():
             if filename is None:
                 module.fail_json(msg="filename is required for export")
 
-            export_binary(module, xapi, filename)
+            save_binary(module, xapi, category, filename)
 
     elif category == "filter-pcap":
 
@@ -460,7 +466,7 @@ def main():
             if filename is None:
                 module.fail_json(msg="filename is required for export")
 
-            export_binary(module, xapi, filename)
+            save_binary(module, xapi, category, filename)
 
     elif category == "dlp-pcap":
         from_name = module.params["dlp_pcap_name"]
@@ -485,7 +491,7 @@ def main():
             if filename is None:
                 module.fail_json(msg="filename is required for export")
 
-            export_binary(module, xapi, filename)
+            save_binary(module, xapi, category, filename)
 
     elif category == "threat-pcap":
         if filename is None:
@@ -508,7 +514,7 @@ def main():
             search_time=search_time,
             serialno=serial,
         )
-        export_binary(module, xapi, filename)
+        save_binary(module, xapi, category, filename)
 
     module.exit_json(changed=False)
 


### PR DESCRIPTION
## Description
The function `export_binary` was changed to include an extra parameter (`category`), but in several places, the function was being called without passing the `category` parameter. Similar to [PR360](https://github.com/PaloAltoNetworks/pan-os-ansible/pull/360), adding the parameter into calls of export_binary duplicated the calls of xapi.export. In PR360 I duplicated the code from `export_binary` into the calling function; this was not very DRY, but worse, this code would now need to be duplicated several times to fix other code (such as [exporting certs](https://github.com/PaloAltoNetworks/pan-os-ansible/issues/297), PCAPs etc). Instead, I created a `save_binary` function, to make this code DRY; it is the same function code as `export_binary` except it removes the duplicate call to `xapi.export`.

## Motivation and Context
Fixes https://github.com/PaloAltoNetworks/pan-os-ansible/issues/297

## How Has This Been Tested?
Integration testing performed against VM-Series. Test playbook tasks:
```
    - name: Download Stats Dump file
      paloaltonetworks.panos.panos_export:
        provider: "{{ device }}"
        category: "stats-dump"
        filename: "statsdump.tar.gz"

    - name: Download Device State file
      paloaltonetworks.panos.panos_export:
        provider: "{{ device }}"
        category: "device-state"
        filename: "device-state.tgz"

    - name: Download Tech-Support file
      paloaltonetworks.panos.panos_export:
        provider: "{{ device }}"
        category: "tech-support"
        filename: "tech-support.tgz"

    - name: Export cert with keys
      paloaltonetworks.panos.panos_export:
        provider: '{{ device }}'
        category: 'certificate'
        filename: '2023-jamoi-xyz-wildcard.pem'
        certificate_name: '2023-jamoi-xyz-wildcard'
        certificate_format: pem
        certificate_include_keys: true
        certificate_passphrase: 'somethingSecret'

    - name: Download filter PCAP file
      paloaltonetworks.panos.panos_export:
        provider: "{{ device }}"
        category: "filter-pcap"
        filter_pcap_name: "rx"
        filename: "rx.pcap"

    - name: Download Application PCAP file
      paloaltonetworks.panos.panos_export:
        provider: "{{ device }}"
        category: "application-pcap"
        application_pcap_name: "/20230213/192.168.150.17-17500-192.168.150.255-17500-163170.pcap"
        filename: "app.pcap"

    - name: Download Threat PCAP file
      paloaltonetworks.panos.panos_export:
        provider: "{{ device }}"
        category: "threat-pcap"
        threat_pcap_id: "1209149423666345685"
        threat_pcap_search_time: "2023/02/13 16:33:12"
        filename: "threat.pcap"

    - name: Download DLP PCAP file
      paloaltonetworks.panos.panos_export:
        provider: "{{ device }}"
        category: "dlp-pcap"
        dlp_password: "superSecret"
        dlp_pcap_name: "20230213/192.168.150.49-59018-104.154.89.105-443-154006"
        filename: "dlp.pcap"
```
Results:
```
PLAY [Export ops-related files] *************************************************************************************************************************

TASK [Gathering Facts] **********************************************************************************************************************************
ok: [host_vm-series-a]

TASK [Download Stats Dump file] *************************************************************************************************************************
ok: [host_vm-series-a]

TASK [Download Device State file] ***********************************************************************************************************************
ok: [host_vm-series-a]

TASK [Download Tech-Support file] ***********************************************************************************************************************
ok: [host_vm-series-a]

TASK [Export cert with keys] ****************************************************************************************************************************
ok: [host_vm-series-a]

TASK [Download filter PCAP file] ************************************************************************************************************************
ok: [host_vm-series-a]

TASK [Download Application PCAP file] *******************************************************************************************************************
ok: [host_vm-series-a]

TASK [Download Threat PCAP file] ************************************************************************************************************************
ok: [host_vm-series-a]

TASK [Download DLP PCAP file] ***************************************************************************************************************************
ok: [host_vm-series-a]

PLAY RECAP **********************************************************************************************************************************************
host_vm-series-a           : ok=9    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
```

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.