### PR TITLE
Remove default "any" to avoid issues

### DIFF
--- a/plugins/modules/panos_security_rule.py
+++ b/plugins/modules/panos_security_rule.py
@@ -398,20 +398,20 @@ def main():
         sdk_params=dict(
             rule_name=dict(required=True, sdk_param="name"),
             source_zone=dict(
-                type="list", elements="str", default=["any"], sdk_param="fromzone"
+                type="list", elements="str", default=[], sdk_param="fromzone"
             ),
             source_ip=dict(
-                type="list", elements="str", default=["any"], sdk_param="source"
+                type="list", elements="str", default=[], sdk_param="source"
             ),
             source_user=dict(type="list", elements="str", default=["any"]),
             hip_profiles=dict(type="list", elements="str"),
             destination_zone=dict(
-                type="list", elements="str", default=["any"], sdk_param="tozone"
+                type="list", elements="str", default=[], sdk_param="tozone"
             ),
             destination_ip=dict(
-                type="list", elements="str", default=["any"], sdk_param="destination"
+                type="list", elements="str", default=[], sdk_param="destination"
             ),
-            application=dict(type="list", elements="str", default=["any"]),
+            application=dict(type="list", elements="str", default=[]),
             service=dict(type="list", elements="str", default=["application-default"]),
             category=dict(type="list", elements="str", default=["any"]),
             action=dict(


### PR DESCRIPTION
Default values of Application, Source/Destination Zone and IP addresses are set to "any".
When adding a new rule, we do specify the zones and IP addresses, so default value is nullified. 
However, when editing an existing rule, the "any" is added over the existing rule, resulting in total purpose of that specific rule. So removing these "any" default values from the security rule can save extra effort and errors/issues.

## Description

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
