### PR TITLE
ci: Add changelog generator to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,7 +144,7 @@ jobs:
           semantic_version: 17.1.1
           extra_plugins: |
             conventional-changelog-conventionalcommits@^4.4.0
-            @semantic-release/changelog@^6.0.0
+            @semantic-release/changelog@^5.0.1
             @semantic-release/git@^9.0.0
             @semantic-release/exec@^5.0.0
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,6 +144,7 @@ jobs:
           semantic_version: 17.1.1
           extra_plugins: |
             conventional-changelog-conventionalcommits@^4.4.0
+            @semantic-release/changelog@^6.0.0
             @semantic-release/git@^9.0.0
             @semantic-release/exec@^5.0.0
         env:

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -13,11 +13,18 @@
             }
         ],
         [
+            "@semantic-release/changelog",
+            {
+              "changelogFile": "./CHANGELOG.md"
+            }
+        ],
+        [
             "@semantic-release/git",
             {
                 "assets": [
                     "galaxy.yml",
-                    "docs/source/index.rst"
+                    "docs/source/index.rst",
+                    "./CHANGELOG.md"
                 ],
                 "message": "chore(release): ${nextRelease.version}\n\n${nextRelease.notes}"
             }

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -106,7 +106,7 @@ $ git push origin name-of-your-bugfix-or-feature
 This workflow requires node, npm, and semantic-release to be installed locally:
 
 ```
-$ npm install -g semantic-release@^17.1.1 @semantic-release/changelog@^6.0.0 @semantic-release/git@^9.0.0 @semantic-release/exec@^5.0.0 conventional-changelog-conventionalcommits@^4.4.0
+$ npm install -g semantic-release@^17.1.1 @semantic-release/changelog@^5.0.1 @semantic-release/git@^9.0.0 @semantic-release/exec@^5.0.0 conventional-changelog-conventionalcommits@^4.4.0
 ```
 
 ### Test the release process

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -106,7 +106,7 @@ $ git push origin name-of-your-bugfix-or-feature
 This workflow requires node, npm, and semantic-release to be installed locally:
 
 ```
-$ npm install -g semantic-release@^17.1.1 @semantic-release/git@^9.0.0 @semantic-release/exec@^5.0.0 conventional-changelog-conventionalcommits@^4.4.0
+$ npm install -g semantic-release@^17.1.1 @semantic-release/changelog@^6.0.0 @semantic-release/git@^9.0.0 @semantic-release/exec@^5.0.0 conventional-changelog-conventionalcommits@^4.4.0
 ```
 
 ### Test the release process


### PR DESCRIPTION
## Description
Adds plugin to semantic-release to generate changelog files

## Motivation and Context
Replaces the current system, where `CHANGELOG.md` points to the GitHub releases page

## How Has This Been Tested?
Tested on a separate repo. Needed to alter changelog plugin version from 6.0.0 to 5.0.1 in order to satisfy dependencies with existing versions of other plugins. Initial fail:
```
$ npm install conventional-changelog-conventionalcommits@^4.4.0 @semantic-release/changelog@^6.0.0 @semantic-release/git@^9.0.0 @semantic-release/exec@^5.0.0
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR! 
npm ERR! Found: semantic-release@20.1.0
npm ERR! node_modules/semantic-release
npm ERR!   peer semantic-release@">=18.0.0" from @semantic-release/changelog@6.0.2
npm ERR!   node_modules/@semantic-release/changelog
npm ERR!     @semantic-release/changelog@"^6.0.0" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! @semantic-release/exec@"^5.0.0" from the root project
npm ERR! 
npm ERR! Conflicting peer dependency: semantic-release@17.4.7
npm ERR! node_modules/semantic-release
npm ERR!   peer semantic-release@">=16.0.0 <18.0.0" from @semantic-release/exec@5.0.0
npm ERR!   node_modules/@semantic-release/exec
npm ERR!     @semantic-release/exec@"^5.0.0" from the root project
```
Follow-up success:
```
$ npm install conventional-changelog-conventionalcommits@^4.4.0 @semantic-release/changelog@^5.0.1 @semantic-release/git@^9.0.0 @semantic-release/exec@^5.0.0

added 329 packages, and audited 587 packages in 22s
```

## Types of changes
- CI change

## Checklist
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.