### PR TITLE
fix(panos_commit_push):commit_push fail messaging

### DIFF
--- a/plugins/modules/panos_commit_push.py
+++ b/plugins/modules/panos_commit_push.py
@@ -208,7 +208,16 @@ def main():
         commit_results["jobid"] = int(result)
     elif not result["success"]:
         # The commit failed
-        module.fail_json(msg=" | ".join(result["messages"]))
+        fail_message = "Job ID " + result["jobid"] + ": "
+        
+        for device in result["devices"].items(): # Iterate over all devices that received the commit_push
+            # In the tuples being iterated over here, index 0 is the serial number, index 1 is a dict of commit output messaging
+            
+            if not device[1]["success"]: # For any devices where the commit_push was not successful...
+                # Add the name of the device and the commit messages
+                fail_message += device[1]["name"] + ": " + " | ".join(device[1]["messages"]) + "; "
+
+        module.fail_json(msg=fail_message)
     else:
         # The commit succeeded
         commit_results["changed"] = True

--- a/plugins/modules/panos_commit_push.py
+++ b/plugins/modules/panos_commit_push.py
@@ -210,12 +210,18 @@ def main():
         # The commit failed
         fail_message = "Job ID " + result["jobid"] + ": "
 
-        for device in result["devices"].items():  # Iterate over all devices that received the commit_push
+        for device in result[
+            "devices"
+        ].items():  # Iterate over all devices that received the commit_push
             # In the tuples being iterated over here, index 0 is the serial number, index 1 is a dict of commit output messaging
 
-            if not device[1]["success"]:  # For any devices where the commit_push was not successful...
+            if not device[1][
+                "success"
+            ]:  # For any devices where the commit_push was not successful...
                 # Add the name of the device and the commit messages
-                fail_message += device[1]["name"] + ": " + " | ".join(device[1]["messages"]) + "; "
+                fail_message += (
+                    device[1]["name"] + ": " + " | ".join(device[1]["messages"]) + "; "
+                )
 
         module.fail_json(msg=fail_message)
     else:

--- a/plugins/modules/panos_commit_push.py
+++ b/plugins/modules/panos_commit_push.py
@@ -209,11 +209,11 @@ def main():
     elif not result["success"]:
         # The commit failed
         fail_message = "Job ID " + result["jobid"] + ": "
-        
-        for device in result["devices"].items(): # Iterate over all devices that received the commit_push
+
+        for device in result["devices"].items():  # Iterate over all devices that received the commit_push
             # In the tuples being iterated over here, index 0 is the serial number, index 1 is a dict of commit output messaging
-            
-            if not device[1]["success"]: # For any devices where the commit_push was not successful...
+
+            if not device[1]["success"]:  # For any devices where the commit_push was not successful...
                 # Add the name of the device and the commit messages
                 fail_message += device[1]["name"] + ": " + " | ".join(device[1]["messages"]) + "; "
 


### PR DESCRIPTION
## Description
Adds messaging for the use when a panos_commit_push operation fails

## Motivation and Context
Fixes #403

It looks like the `messages` that were previously being returned in `module.fail_json` are always empty for a commit_push. The messages content is now a few levels deeper, and is returned per device, needing some iteration of the devices being targeted with the `commit_push` in order to surface them to the user.

## How Has This Been Tested?
Tested locally.
With a single managed device:
```
TASK [Commit and push config via Panorama] *****************************************************************************************
fatal: [host_homelabrama]: FAILED! => {"changed": false, "msg": "Job ID 1235286: vm-series-test: Validation Error: |  address -> aaaa-123123 'aaaa-123123' is already in use |  address is invalid | vsys1 |     Error: Duplicate address name 'aaaa-123123' | (Module: device) | client device phase 1 failure | Commit failed"}
```
With a HA pair of managed devices:
```
TASK [Commit and push config via Panorama] *************************************************************************************************************************
fatal: [host_homelabrama]: FAILED! => {"changed": false, "msg": "Job ID 1235449: vm-series-02: Validation Error: |  address -> aaaa-123123 'aaaa-123123' is already in use |  address is invalid | vsys1 |     Error: Duplicate address name 'aaaa-123123' | (Module: device) | client device phase 1 failure | Commit failed; vm-series-01: Validation Error: |  address -> aaaa-123123 'aaaa-123123' is already in use |  address is invalid | vsys1 |     Error: Duplicate address name 'aaaa-123123' | (Module: device) | client device phase 1 failure | Commit failed; "}
```

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.