### PR TITLE
feat(panos_import): Add private key blocking to keypair import

### DIFF
--- a/plugins/modules/panos_import.py
+++ b/plugins/modules/panos_import.py
@@ -104,8 +104,8 @@ options:
             - If this parameter is left undefined, the effective value with be no.
         type: str
         choices:
-            - no
-            - yes
+            - "no"
+            - "yes"
     custom_logo_location:
         description:
             - When I(category=custom-logo), import this logo file here.

--- a/plugins/modules/panos_import.py
+++ b/plugins/modules/panos_import.py
@@ -98,6 +98,14 @@ options:
         description:
             - Passphrase used to decrypt the certificate and/or private key.
         type: str
+    block_private_key_export:
+        description:
+            - When I(category=keypair), controls if the private key is allowed to be exported from PAN-OS in future.
+            - If this parameter is left undefined, the effective value with be no.
+        type: str
+        choices:
+            - no
+            - yes
     custom_logo_location:
         description:
             - When I(category=custom-logo), import this logo file here.
@@ -286,6 +294,7 @@ def main():
             certificate_name=dict(type="str"),
             format=dict(type="str", choices=["pem", "pkcs12"]),
             passphrase=dict(type="str", no_log=True),
+            block_private_key_export=dict(type="str", choices=["yes", "no"]),
             custom_logo_location=dict(
                 type="str",
                 choices=[
@@ -334,6 +343,7 @@ def main():
         params["certificate-name"] = module.params["certificate_name"]
         params["format"] = module.params["format"]
         params["passphrase"] = module.params["passphrase"]
+        params["block-private-key"] = module.params["block_private_key_export"]
 
     elif category == "custom-logo":
         params["where"] = module.params["custom_logo_location"]

--- a/plugins/modules/panos_import.py
+++ b/plugins/modules/panos_import.py
@@ -102,10 +102,7 @@ options:
         description:
             - When I(category=keypair), controls if the private key is allowed to be exported from PAN-OS in future.
             - If this parameter is left undefined, the effective value with be no.
-        type: str
-        choices:
-            - "no"
-            - "yes"
+        type: bool
     custom_logo_location:
         description:
             - When I(category=custom-logo), import this logo file here.
@@ -294,7 +291,7 @@ def main():
             certificate_name=dict(type="str"),
             format=dict(type="str", choices=["pem", "pkcs12"]),
             passphrase=dict(type="str", no_log=True),
-            block_private_key_export=dict(type="str", choices=["yes", "no"]),
+            block_private_key_export=dict(type="bool"),
             custom_logo_location=dict(
                 type="str",
                 choices=[
@@ -343,7 +340,14 @@ def main():
         params["certificate-name"] = module.params["certificate_name"]
         params["format"] = module.params["format"]
         params["passphrase"] = module.params["passphrase"]
-        params["block-private-key"] = module.params["block_private_key_export"]
+        src = "block_private_key_export"
+        dst = "block-private-key"
+        if module.params[src] is None:
+            params[dst] = None
+        elif module.params[src] == True:
+            params[dst] = "yes"
+        else:
+            params[dst] = "no"
 
     elif category == "custom-logo":
         params["where"] = module.params["custom_logo_location"]

--- a/plugins/modules/panos_import.py
+++ b/plugins/modules/panos_import.py
@@ -344,7 +344,7 @@ def main():
         dst = "block-private-key"
         if module.params[src] is None:
             params[dst] = None
-        elif module.params[src] is True:
+        elif module.params[src]:
             params[dst] = "yes"
         else:
             params[dst] = "no"

--- a/plugins/modules/panos_import.py
+++ b/plugins/modules/panos_import.py
@@ -344,7 +344,7 @@ def main():
         dst = "block-private-key"
         if module.params[src] is None:
             params[dst] = None
-        elif module.params[src] == True:
+        elif module.params[src] is True:
             params[dst] = "yes"
         else:
             params[dst] = "no"


### PR DESCRIPTION
## Description
Adds the ability, at the time of importing a keypair, to block the private key from being exported from PAN-OS in future

## Motivation and Context
Closes #415
[Blocking export of private keys was introduced in PAN-OS 10.0](https://docs.paloaltonetworks.com/pan-os/10-0/pan-os-new-features/decryption-features/block-export-of-private-keys)

## How Has This Been Tested?
Tested locally

## Screenshots (if appropriate)
Testing screenshot:
![Screenshot 2023-04-06 at 16 01 09](https://user-images.githubusercontent.com/6574404/230419483-562912b8-ad9a-4f56-b2f1-d2431f1b37e0.png)

## Types of changes
- New feature (non-breaking change which adds functionality)

## Checklist
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.