### PR TITLE
Fixed auth type `non-auth` for IKE profile

### DIFF
--- a/plugins/modules/panos_ike_crypto_profile.py
+++ b/plugins/modules/panos_ike_crypto_profile.py
@@ -59,7 +59,7 @@ options:
             - Authentication hashes used for IKE phase 1 proposal.
         type: list
         elements: str
-        choices: ['none', 'md5', 'sha1', 'sha256', 'sha384', 'sha512']
+        choices: ['non-auth', 'md5', 'sha1', 'sha256', 'sha384', 'sha512']
         default: ['sha1']
     encryption:
         description:
@@ -166,7 +166,7 @@ def main():
             authentication=dict(
                 type="list",
                 elements="str",
-                choices=["none", "md5", "sha1", "sha256", "sha384", "sha512"],
+                choices=["non-auth", "md5", "sha1", "sha256", "sha384", "sha512"],
                 default=["sha1"],
             ),
             encryption=dict(


### PR DESCRIPTION
## Description

IKE profile takes `non-auth` and not `none` as an authentication hash type.

```
TASK [palo_alto : Create Secure IKE Crypto Profile] ***************************************************************************************
fatal: [TEST_PaloAlto.hostname]: FAILED! => {"changed": false, "msg": "Failed apply:  TEST-IKE-Crypto-Profile -> hash 'none' is not an allowed keyword\n TEST-IKE-Crypto-Profile -> hash is invalid"}
```

## Motivation and Context

`aes-gcm-256` encryption has built in authentication, so you need to set the authentication to `non-auth`.

## How Has This Been Tested?

Tested running the following on Rocky 8:
```
- name: Create Secure IKE Crypto Profile
  paloaltonetworks.panos.panos_ike_crypto_profile:
  ip_address: "{{ firewall_ip }}" #TEMP FOR SCRIPT TESTING, Used for ansible connection to PA
  username: "{{ username }}"
  password: "{{ password }}"
  state: 'present'
  name: 'TEST-IKE-Crypto-Profile'
  dh_group: ['group20']
  #authentication: 'none' #BUG: Authenication will leave at default "sha1" when using "none"
  authentication: 'non-auth'
  encryption: ['aes-256-gcm']
  lifetime_seconds: '28800'
```

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
