### PR TITLE
feat(panos_aggregate_interface): Add fast failover for LACP

### DIFF
--- a/plugins/modules/panos_aggregate_interface.py
+++ b/plugins/modules/panos_aggregate_interface.py
@@ -133,6 +133,10 @@ options:
             - Set LACP mode
         type: str
         choices: ['active', 'passive']
+    lacp_fast_failover:
+        description:
+            - Enable LACP fast failover
+        type: bool
     zone_name:
         description:
             - The zone to put this interface into.
@@ -212,6 +216,7 @@ def main():
             lacp_passive_pre_negotiation=dict(type="bool"),
             lacp_rate=dict(type="str", choices=["fast", "slow"]),
             lacp_mode=dict(type="str", choices=["active", "passive"]),
+            lacp_fast_failover=dict(type="bool"),
         ),
     )
 


### PR DESCRIPTION
## Description
Adds the option to configure `fast failover` for LACP on aggregate network interfaces

## Motivation and Context
Adds the option to configure `fast failover` for LACP on aggregate network interfaces

This requires [the prerequisite change in pan-os-python](https://github.com/PaloAltoNetworks/pan-os-python/pull/502) to be merged first

Closes https://github.com/PaloAltoNetworks/pan-os-ansible/issues/422

## How Has This Been Tested?
Tested locally against PA-5220

## Screenshots (if appropriate)
Testing via Ansible playbook:
![Screenshot 2023-04-18 at 10 48 26](https://user-images.githubusercontent.com/6574404/232740287-46f5fe58-f5b5-4791-bd60-f2f50f51bb1e.png)
![Screenshot 2023-04-18 at 10 49 18](https://user-images.githubusercontent.com/6574404/232740311-bea7d417-8ff2-4cbc-a5a0-a30d4d0f6577.png)
![Screenshot 2023-04-18 at 10 49 45](https://user-images.githubusercontent.com/6574404/232740329-94bc3f88-053d-4807-967e-0a4b25d6c376.png)

## Types of changes
- New feature (non-breaking change which adds functionality)

## Checklist
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.