### PR TITLE
docs: HIP profile PAN-OS version clarification

### DIFF
--- a/plugins/modules/panos_security_rule.py
+++ b/plugins/modules/panos_security_rule.py
@@ -92,7 +92,7 @@ options:
             - NOTE: If I(state=present) or I(state=replaced), and you're running
               PAN-OS < 10.0.0, then this will have a default of I(["any"]).
             - If you are using PAN-OS >= 10.0.0, please do not use this
-              hip-profile parameter as it was removed from PAN-OS in 10.0.0.
+              parameter as it was removed from PAN-OS in 10.0.0.
         type: list
         elements: str
     destination_zone:

--- a/plugins/modules/panos_security_rule.py
+++ b/plugins/modules/panos_security_rule.py
@@ -91,6 +91,8 @@ options:
               HIP that notifies the firewall about the user's local configuration.
             - NOTE: If I(state=present) or I(state=replaced), and you're running
               PAN-OS < 10.0.0, then this will have a default of I(["any"]).
+            - If you are using PAN-OS >= 10.0.0, please do not use this
+              hip-profile parameter as it was removed from PAN-OS in 10.0.0.
         type: list
         elements: str
     destination_zone:


### PR DESCRIPTION
## Description
Docs update, clarifying PAN-OS versions for the HIP profile parameter

## Motivation and Context
It came up during a [customer query on LIVEcommunity](https://live.paloaltonetworks.com/t5/automation-api-discussions/error-certfile-should-be-a-valid-filesystem-path/td-p/539882)

## How Has This Been Tested?
N/A - Docs

## Types of changes
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)
N/A - Docs

## Checklist
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.