### PR TITLE
feat(panos_http_profile): feat: Decrypt and GP for HTTP profiles

### DIFF
--- a/plugins/modules/panos_http_profile.py
+++ b/plugins/modules/panos_http_profile.py
@@ -224,15 +224,64 @@ options:
             - PAN-OS 9.0+.
             - Payload for custom config format.
         type: str
+    globalprotect_name:
+        description:
+            - PAN-OS 9.1+.
+            - Name for custom GlobalProtect format.
+        type: str
+    globalprotect_uri_format:
+        description:
+            - PAN-OS 9.1+.
+            - URI format for custom GlobalProtect format.
+        type: str
+    globalprotect_payload:
+        description:
+            - PAN-OS 9.1+.
+            - Payload for custom GlobalProtect format.
+        type: str
+    decryption_name:
+        description:
+            - PAN-OS 10.0+.
+            - Name for custom decryption format.
+        type: str
+    decryption_uri_format:
+        description:
+            - PAN-OS 10.0+.
+            - URI format for custom decryption format.
+        type: str
+    decryption_payload:
+        description:
+            - PAN-OS 10.0+.
+            - Payload for custom decryption format.
+        type: str
 """
 
 EXAMPLES = """
 # Create a profile
-- name: Create http profile
-  panos_http_profile:
+- name: Create http profile with tag registration
+  paloaltonetworks.panos.panos_http_profile:
     provider: '{{ provider }}'
     name: 'my-profile'
     tag_registration: true
+
+- name: Create http profile for traffic log forwarding
+    paloaltonetworks.panos.panos_http_profile:
+    provider: '{{ provider }}'
+    name: 'my-profile'
+    traffic_name: 'traffic-logs-exporter'
+    traffic_uri_format: 'https://test.local'
+    traffic_payload: >
+        {
+            "category": "network",
+            "action": "$action",
+            "app": "$app",
+            "dst": "$dst",
+            "src": "$src",
+            "receive_time": "$receive_time",
+            "rule": "$rule",
+            "rule_uuid": "$rule_uuid",
+            "sessionid": "$sessionid",
+        }
 """
 
 RETURN = """
@@ -252,7 +301,7 @@ def main():
         with_network_resource_module_state=True,
         with_gathered_filter=True,
         with_classic_provider_spec=True,
-        min_pandevice_version=(0, 11, 1),
+        min_pandevice_version=(1, 10, 0),
         min_panos_version=(8, 0, 0),
         sdk_cls=("device", "HttpServerProfile"),
         sdk_params=dict(
@@ -300,6 +349,12 @@ def main():
             iptag_name=dict(),
             iptag_uri_format=dict(),
             iptag_payload=dict(),
+            globalprotect_name=dict(),
+            globalprotect_uri_format=dict(),
+            globalprotect_payload=dict(),
+            decryption_name=dict(),
+            decryption_uri_format=dict(),
+            decryption_payload=dict(),
         ),
     )
 

--- a/plugins/modules/panos_http_profile.py
+++ b/plugins/modules/panos_http_profile.py
@@ -264,8 +264,9 @@ EXAMPLES = """
     name: 'my-profile'
     tag_registration: true
 
+# Create a profile with log forwarding
 - name: Create http profile for traffic log forwarding
-    paloaltonetworks.panos.panos_http_profile:
+  paloaltonetworks.panos.panos_http_profile:
     provider: '{{ provider }}'
     name: 'my-profile'
     traffic_name: 'traffic-logs-exporter'

--- a/plugins/modules/panos_http_profile_header.py
+++ b/plugins/modules/panos_http_profile_header.py
@@ -51,20 +51,22 @@ options:
             - The log type for this header.
         type: str
         choices:
+            - auth
             - config
+            - data
+            - decryption
+            - globalprotect
+            - gtp
+            - hip match
+            - iptag
+            - sctp
             - system
             - threat
             - traffic
-            - hip match
-            - url
-            - data
-            - wildfire
             - tunnel
+            - url
             - user id
-            - gtp
-            - auth
-            - sctp
-            - iptag
+            - wildfire
         required: True
     header:
         description:
@@ -114,6 +116,8 @@ class Helper(ConnectionHelper):
             "auth": "HttpAuthHeader",
             "sctp": "HttpSctpHeader",
             "iptag": "HttpIpTagHeader",
+            "decryption": "HttpDecryptionHeader",
+            "globalprotect": "HttpGlobalProtectHeader",
         }
 
         self.sdk_cls = ("device", cls_map[module.params["log_type"]])
@@ -127,7 +131,7 @@ def main():
         with_network_resource_module_state=True,
         with_gathered_filter=True,
         with_classic_provider_spec=True,
-        min_pandevice_version=(0, 11, 1),
+        min_pandevice_version=(1, 10, 0),
         min_panos_version=(8, 0, 0),
         parents=(("device", "HttpServerProfile", "http_profile"),),
         sdk_params=dict(
@@ -152,6 +156,8 @@ def main():
                     "auth",
                     "sctp",
                     "iptag",
+                    "decryption",
+                    "globalprotect",
                 ],
             ),
         ),

--- a/plugins/modules/panos_http_profile_param.py
+++ b/plugins/modules/panos_http_profile_param.py
@@ -51,20 +51,22 @@ options:
             - The log type for this parameter.
         type: str
         choices:
+            - auth
             - config
+            - data
+            - decryption
+            - globalprotect
+            - gtp
+            - hip match
+            - iptag
+            - sctp
             - system
             - threat
             - traffic
-            - hip match
-            - url
-            - data
-            - wildfire
             - tunnel
+            - url
             - user id
-            - gtp
-            - auth
-            - sctp
-            - iptag
+            - wildfire
         required: True
     param:
         description:
@@ -114,6 +116,8 @@ class Helper(ConnectionHelper):
             "auth": "HttpAuthParam",
             "sctp": "HttpSctpParam",
             "iptag": "HttpIpTagParam",
+            "decryption": "HttpDecryptionParam",
+            "globalprotect": "HttpGlobalProtectParam",
         }
 
         self.sdk_cls = ("device", cls_map[module.params["log_type"]])
@@ -127,7 +131,7 @@ def main():
         with_network_resource_module_state=True,
         with_gathered_filter=True,
         with_classic_provider_spec=True,
-        min_pandevice_version=(0, 11, 1),
+        min_pandevice_version=(1, 10, 0),
         min_panos_version=(8, 0, 0),
         parents=(("device", "HttpServerProfile", "http_profile"),),
         sdk_params=dict(
@@ -152,6 +156,8 @@ def main():
                     "auth",
                     "sctp",
                     "iptag",
+                    "decryption",
+                    "globalprotect",
                 ],
             ),
         ),


### PR DESCRIPTION
## Description
Adds the option for HTTP Server Profiles to key off Decrypt and GP logs.
Whilst I was there, I also alphabetically ordered the `choices` in the docs for the header/params modules.

## Motivation and Context
Decrypt and GP logs were added in PAN-OS 10.0 and 9.1 respectively.
This feature coverage is also useful for upcoming Event-Driven Ansible operations.

## How Has This Been Tested?
Tested locally ([playbook](https://github.com/jamesholland-uk/playground/blob/main/pan-os-ansible/http-server-profiles.yml))

## Screenshots (if appropriate)
![Screenshot 2023-04-26 at 14 54 11](https://user-images.githubusercontent.com/6574404/234622078-db6456f5-8e8d-45e5-8775-c3817708ca18.png)
![Screenshot 2023-04-26 at 14 51 38](https://user-images.githubusercontent.com/6574404/234622157-329a93b5-2c6c-4615-a265-0e5c0b0e4c9a.png)
![Screenshot 2023-04-26 at 14 50 45](https://user-images.githubusercontent.com/6574404/234622180-689eae2f-9a77-4b61-aea8-568bfd92d4ff.png)
![Screenshot 2023-04-26 at 14 51 01](https://user-images.githubusercontent.com/6574404/234622202-8f105919-68c9-4f95-9b5d-0ff88dacdfb4.png)

## Types of changes
- New feature (non-breaking change which adds functionality)

## Checklist
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.