### PR TITLE
feat(panos_log_forwarding_profile_match_list): Add decryption log-type to log forwarding

### DIFF
--- a/plugins/modules/panos_log_forwarding_profile_match_list.py
+++ b/plugins/modules/panos_log_forwarding_profile_match_list.py
@@ -67,6 +67,7 @@ options:
             - tunnel
             - auth
             - sctp
+            - decryption
         default: 'traffic'
     filter:
         description:
@@ -128,7 +129,7 @@ def main():
         with_network_resource_module_state=True,
         with_gathered_filter=True,
         with_classic_provider_spec=True,
-        min_pandevice_version=(0, 11, 1),
+        min_pandevice_version=(1, 11, 0),
         min_panos_version=(8, 0, 0),
         parents=(("objects", "LogForwardingProfile", "log_forwarding_profile"),),
         sdk_cls=("objects", "LogForwardingProfileMatchList"),
@@ -147,6 +148,7 @@ def main():
                     "tunnel",
                     "auth",
                     "sctp",
+                    "decryption",
                 ],
             ),
             filter=dict(),


### PR DESCRIPTION
## Description
Add decryption log-type to log forwarding

## Motivation and Context
Decryption logs were added in PAN-OS 10.0

## How Has This Been Tested?
Tested locally with Ansible

## Screenshots (if appropriate)
Before:
![Screenshot 2023-05-02 at 15 07 46](https://user-images.githubusercontent.com/6574404/235692040-3c8449ba-c3e5-40c0-89a4-6ecbf8f1bf42.png)

After:
![Screenshot 2023-05-02 at 15 07 56](https://user-images.githubusercontent.com/6574404/235692056-6375a2b1-8857-4848-86a8-41c1f9c2a8d2.png)

## Types of changes
- New feature (non-breaking change which adds functionality)

## Checklist
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.