### PR TITLE
test: add python version for tests

### DIFF
--- a/tests/config.yml
+++ b/tests/config.yml
@@ -1,0 +1,40 @@
+# Support for this feature was first added in ansible-core 2.12.
+# Use of this file is optional.
+# If used, this file must be placed in "tests/config.yml" relative to the base of the collection.
+modules:
+  # Configuration for modules/module_utils.
+  # These settings do not apply to other content in the collection.
+
+  python_requires: '>=3.8'
+  # Python versions supported by modules/module_utils.
+  # This setting is required.
+  #
+  # Possible values:
+  #
+  #  - 'default'    - All Python versions supported by Ansible.
+  #                   This is the default value if no configuration is provided.
+  #  - 'controller' - All Python versions supported by the Ansible controller.
+  #                   This indicates the modules/module_utils can only run on the controller.
+  #                   Intended for use only with modules/module_utils that depend on ansible-connection, which only runs on the controller.
+  #                   Unit tests for modules/module_utils will be permitted to import any Ansible code, instead of only module_utils.
+  #  - SpecifierSet - A PEP 440 specifier set indicating the supported Python versions.
+  #                   This is only needed when modules/module_utils do not support all Python versions supported by Ansible.
+  #                   It is not necessary to exclude versions which Ansible does not support, as this will be done automatically.
+  #
+  # What does this affect?
+  #
+  #  - Unit tests will be skipped on any unsupported Python version.
+  #  - Sanity tests that are Python version specific will be skipped on any unsupported Python version that is not supported by the controller.
+  #
+  # Sanity tests that are Python version specific will always be executed for Python versions supported by the controller, regardless of this setting.
+  # Reasons for this restriction include, but are not limited to:
+  #
+  #  - AnsiballZ must be able to AST parse modules/module_utils on the controller, even though they may execute on a managed node.
+  #  - ansible-doc must be able to AST parse modules/module_utils on the controller to display documentation.
+  #  - ansible-test must be able to AST parse modules/module_utils to perform static analysis on them.
+  #  - ansible-test must be able to execute portions of modules/module_utils to validate their argument specs.
+  #
+  # These settings only apply to modules/module_utils.
+  # It is not possible to declare supported Python versions for controller-only code.
+  # All Python versions supported by the controller must be supported by controller-only code.
+  


### PR DESCRIPTION
## Description
This PR adds a config file which controls the version of Python used for unit and sanity tests. The version in the config file matches the currently version currently supported by the collection, `>=3.8`.

## Motivation and Context
Currently, during collection import to Galaxy/AutomationHub, compile errors are observed during sanity tests for Python versions 2.7 and 3.5:
```
Running sanity test "compile" on Python 2.7 
ERROR: Found 3 compile issue(s) on python 2.7 which need to be resolved: 
ERROR: plugins/module_utils/panos.py:707:35: SyntaxError: **ref_spec, 
ERROR: plugins/modules/panos_config_element.py:293:32: SyntaxError: f"<{outer}>" + element_xml + f"</{outer}>" 
ERROR: plugins/modules/panos_userid.py:119:21: SyntaxError: **extras, 
See documentation for help: https://docs.ansible.com/ansible-core/2.14/dev_guide/testing/sanity/compile.html 
Running sanity test "compile" on Python 3.5 
ERROR: Found 1 compile issue(s) on python 3.5 which need to be resolved: 
ERROR: plugins/modules/panos_config_element.py:293:32: SyntaxError: f"<{outer}>" + element_xml + f"</{outer}>" 
```
These are effectively false positives since Python versions 2.7 and 3.5 are not supported by this collection. The config file should stop sanity tests being executed against version <3.8, and clean up the import log.
This idea was suggested by Red Hat Partner engineering, with [this reference](https://github.com/ansible/ansible/blob/devel/test/lib/ansible_test/config/config.yml), and [this example](https://github.com/F5Networks/f5-ansible-f5modules/blob/main/ansible_collections/f5networks/f5_modules/tests/config.yml).

## How Has This Been Tested?
Attempted to run sanity tests locally, it appears to work (without the config file, I get errors because my laptop's Python 3.7 is broken... with the config file, the errors are not displayed, indicating 3.7 has not been attempted). True testing will be with the next release and import to Galaxy/AutomationHub.

## Screenshots (if appropriate)
N/A

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.