### PR TITLE
ci: Fix for antsibull-docs v2 dependency issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,7 +189,7 @@ jobs:
         run: poetry add ansible-core^2.13
 
       - name: Add antsibull-docs
-        run: poetry add antsibull-docs
+        run: poetry add antsibull-docs^1.11.0
 
       - name: Install dependencies
         run: poetry install


### PR DESCRIPTION
## Description
Adds version specification within CI for `antsibull-docs`

## Motivation and Context
`antsibull-docs` released v2.0 which was used by the docs task in CI for the most recent release, and this had a dependency issue with Python versions. Reverting to using v1.11.0 fixes the issue

## How Has This Been Tested?
Tested locally

## Screenshots (if appropriate)
Before this fix (`antsibull-docs` v2.0):
![Screenshot 2023-06-14 at 11 50 39](https://github.com/PaloAltoNetworks/pan-os-ansible/assets/6574404/e7619bd2-9ce9-4b44-a71a-64a19eddc13f)

After this fix (`antsibull-docs` v1.11.0):
![Screenshot 2023-06-14 at 11 50 48](https://github.com/PaloAltoNetworks/pan-os-ansible/assets/6574404/1e0bc5de-636b-43eb-85fa-fb97c1da7de9)

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.