### PR TITLE
fix(panos_admpwd): Fix success criteria and update example in docs

### DIFF
--- a/plugins/modules/panos_admpwd.py
+++ b/plugins/modules/panos_admpwd.py
@@ -64,7 +64,7 @@ EXAMPLES = """
     key_filename: "/tmp/ssh.key"
     newpassword: "badpassword"
   register: result
-  until: not result|failed
+  until: result is not failed
   retries: 10
   delay: 30
 """
@@ -166,7 +166,7 @@ def set_panwfw_password(module, ip_address, key_filename, newpassword, username)
     buff = wait_with_timeout(module, shell, "#", 120)
     stdout += buff
 
-    if "success" not in buff:
+    if "Configuration committed successfully" not in buff:
         module.fail_json(msg="Error setting " + username + " password: " + stdout)
 
     # exit

--- a/plugins/modules/panos_admpwd.py
+++ b/plugins/modules/panos_admpwd.py
@@ -166,7 +166,7 @@ def set_panwfw_password(module, ip_address, key_filename, newpassword, username)
     buff = wait_with_timeout(module, shell, "#", 120)
     stdout += buff
 
-    if "Configuration committed successfully" not in buff:
+    if "successfully" not in buff:
         module.fail_json(msg="Error setting " + username + " password: " + stdout)
 
     # exit


### PR DESCRIPTION
## Description
Fix success criteria.
Update example in docs.

## Motivation and Context
Fixes #433.
Per #433, previously the test for success was too generic and was detecting a failed result as success.

Whilst testing for this PR, the example in the documentation was noted to be incorrect since changes in Ansible functionality, so the example code has also been updated.

## How Has This Been Tested?
Tested locally against VM-Series and Panorama.

## Screenshots (if appropriate)
Example of a previous failure, that the module detected as success:
![Screenshot 2023-07-04 at 10 58 05](https://github.com/PaloAltoNetworks/pan-os-ansible/assets/6574404/6e1a7016-7049-4a8e-b7a4-ff2cb40c9b48)
Example of success after the changes in this PR:
![Screenshot 2023-07-04 at 10 57 45](https://github.com/PaloAltoNetworks/pan-os-ansible/assets/6574404/920ba2ca-69a8-4359-bee1-e93d5eb2a645)

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.