### PR TITLE
docs(panos_import): Notes for importing certs and keys

### DIFF
--- a/plugins/modules/panos_import.py
+++ b/plugins/modules/panos_import.py
@@ -37,6 +37,9 @@ requirements:
 extends_documentation_fragment:
     - paloaltonetworks.panos.fragments.transitional_provider
     - paloaltonetworks.panos.fragments.full_template_support
+notes:
+    - I(category=certificate) is used for importing a certificate on its own from a file.
+    - I(category=keypair) is used for importing a certificate and private key from a single file.
 options:
     category:
         description:


### PR DESCRIPTION
## Description
Notes clarifying choices for importing certs and keys, `certificate` versus `keypair`.

## Motivation and Context
More than once, users have been using these two choices incorrectly. Updating docs to aid user education.

## How Has This Been Tested?
N/A

## Types of changes
- Docs

## Checklist
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.