### PR TITLE
fix(panos_bgp_peer_group): Fix for IBGP export next-hop options

### DIFF
--- a/plugins/modules/panos_bgp_peer_group.py
+++ b/plugins/modules/panos_bgp_peer_group.py
@@ -57,6 +57,7 @@ options:
             - Export locally resolved nexthop.
         type: str
         choices:
+            - original
             - resolve
             - use-self
         default: 'resolve'
@@ -138,7 +139,9 @@ def main():
             type=dict(
                 default="ebgp", choices=["ebgp", "ibgp", "ebgp-confed", "ibgp-confed"]
             ),
-            export_nexthop=dict(default="resolve", choices=["resolve", "use-self"]),
+            export_nexthop=dict(
+                default="resolve", choices=["original", "resolve", "use-self"]
+            ),
             import_nexthop=dict(default="original", choices=["original", "use-peer"]),
             remove_private_as=dict(type="bool"),
         ),


### PR DESCRIPTION
## Description
Fix for IBGP `export_nexthop` choices, adding `original` which is a valid choice for IBGP.

**Note:** The default for `export_nexthop` is currently `resolve` which is not valid for IBGP. Users choosing `type: ibgp` will therefore need to explicitly choose `original` or `use-self` for `export_nexthop`, leaving `export_nexthop` undefined will cause an error. Changing the default for `export_nexthop` would constitute a breaking change, so this is why the PR's code is presented as just an extra choice, not a change to the default choice.

## Motivation and Context
Fixes #441

## How Has This Been Tested?
Tested locally:
```
    - name: Create BGP Peer Group
      paloaltonetworks.panos.panos_bgp_peer_group:
        provider: "{{ device }}"
        name: "network4"
        type: "ibgp"
        enable: true
        export_nexthop: 'original'
```

## Screenshots (if appropriate)
Test success:
![Screenshot 2023-07-04 at 13 48 29](https://github.com/PaloAltoNetworks/pan-os-ansible/assets/6574404/d7a0399c-c558-44cd-8863-94ffffe54f4b)

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.