### PR TITLE
fix(panos_ike_crypto_profile): Update DH group choices

### DIFF
--- a/plugins/modules/panos_ike_crypto_profile.py
+++ b/plugins/modules/panos_ike_crypto_profile.py
@@ -50,7 +50,7 @@ options:
             - Specify the priority for Diffie-Hellman (DH) groups.
         type: list
         elements: str
-        choices: ['group1', 'group2', 'group5', 'group14', 'group19', 'group20']
+        choices: ['group1', 'group2', 'group5', 'group14', 'group15', 'group16', 'group19', 'group20', 'group21']
         default: ['group2']
         aliases:
             - dhgroup
@@ -160,7 +160,17 @@ def main():
                 type="list",
                 elements="str",
                 default=["group2"],
-                choices=["group1", "group2", "group5", "group14", "group19", "group20"],
+                choices=[
+                    "group1",
+                    "group2",
+                    "group5",
+                    "group14",
+                    "group15",
+                    "group16",
+                    "group19",
+                    "group20",
+                    "group21",
+                ],
                 aliases=["dhgroup"],
             ),
             authentication=dict(


### PR DESCRIPTION
## Description
Update DH groups choices for current PAN-OS available options

## Motivation and Context
Fixes #460 

## How Has This Been Tested?
Tested locally
    - name: Add IKE crypto profile
      paloaltonetworks.panos.panos_ike_crypto_profile:
        provider: '{{ device }}'
        state: 'present'
        name: 'ike_profile'
        dh_group: ['group1', 'group2', 'group5', 'group14', 'group15', 'group16', 'group19', 'group20', 'group21']
        authentication: ['sha1']
        encryption: ['aes-128-cbc']
        lifetime_seconds: '28800'

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.