### PR TITLE
fix(panos_ipsec_profile): Update DH group choices

### DIFF
--- a/plugins/modules/panos_ipsec_profile.py
+++ b/plugins/modules/panos_ipsec_profile.py
@@ -69,7 +69,7 @@ options:
         description:
             - Diffie-Hellman (DH) groups.
         type: str
-        choices: ['no-pfs', 'group1', 'group2', 'group5', 'group14', 'group19', 'group20']
+        choices: ['no-pfs', 'group1', 'group2', 'group5', 'group14', 'group15', 'group16', 'group19', 'group20', 'group21']
         default: group2
         aliases:
             - dhgroup
@@ -201,8 +201,11 @@ def main():
                     "group2",
                     "group5",
                     "group14",
+                    "group15",
+                    "group16",
                     "group19",
                     "group20",
+                    "group21",
                 ],
                 default="group2",
                 aliases=["dhgroup"],


### PR DESCRIPTION
## Description
Update DH groups choices for current PAN-OS available options

## Motivation and Context
Noticed this needed doing during the fix of #461 

## How Has This Been Tested?
Tested locally
```
    - name: Add IPSec crypto profile
      paloaltonetworks.panos.panos_ipsec_profile:
        provider: '{{ device }}'
        state: 'present'
        name: 'ipsec_profile'
        esp_authentication: ['none']
        esp_encryption: ['aes-128-cbc']
        ah_authentication: ['none']
        dh_group: 'group21'
        lifetime_seconds: '3600'
```

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.