### PR TITLE
fix(panos_software): Modify valid sequence for downloads only

### DIFF
--- a/plugins/modules/panos_software.py
+++ b/plugins/modules/panos_software.py
@@ -211,7 +211,7 @@ def main():
             device.software.check()
 
         if target != current:
-            if not is_valid_sequence(current, target):
+            if not is_valid_sequence(current, target) and install:
                 module.fail_json(
                     msg="Version Sequence is invalid: {0} -> {1}".format(
                         current, target

--- a/plugins/modules/panos_software.py
+++ b/plugins/modules/panos_software.py
@@ -33,6 +33,11 @@ requirements:
 notes:
     - Panorama is supported.
     - Check mode is supported.
+    - When installing PAN-OS software, checking is performed by this module to
+      ensure the upgrade/downgrade path is valid. When using this module to only
+      download and not install PAN-OS software, the valid upgrade/downgrade path
+      checking is bypassed (in order to allow pre-downloading of PAN-OS software
+      images ahead of the installation time for multiple stage upgrades/downgrades).
 extends_documentation_fragment:
     - paloaltonetworks.panos.fragments.transitional_provider
 options:


### PR DESCRIPTION
## Description
Modifies the valid sequence to only be checked if the user is attempting an installation, leaving it unchecked for downloads.

## Motivation and Context
Fixes #454.
It is permitted by PAN-OS to download software which would not be valid to install at the present time, thus allowing the user to pre-download software ready for a later installation, which speeds up the installation work in a change window. Currently the valid sequence check, used to ensure a valid install path is used, is enforced for downloads too. This change removes the check for downloads, as is allowed by PAN-OS.

## Other approaches
The alternative approach is a large change to the code. There would be separate checks for valid download paths and valid installation paths. There is different logic for the validity of each upgrade/downgrade path. There are also changes from PAN-OS 11.0 about being able to skip a certain number of major/minor versions during upgrade/downgrade. For now, the suggestion is that the simple change here is sufficient.

## How Has This Been Tested?
Tested locally with this task for download only:
![Screenshot 2023-07-03 at 11 02 35](https://github.com/PaloAltoNetworks/pan-os-ansible/assets/6574404/49342aa2-0eae-49fc-a2be-adc4b6f14ab5)

Before and after the change in this PR:
![Screenshot 2023-07-03 at 11 02 27](https://github.com/PaloAltoNetworks/pan-os-ansible/assets/6574404/8f0de068-66e1-4afd-a083-115da98710e1)

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.