### PR TITLE
fix(event-driven ansible): Updated code for Red Hat's certification checks

### DIFF
--- a/extensions/eda/plugins/event_source/logs.py
+++ b/extensions/eda/plugins/event_source/logs.py
@@ -33,7 +33,7 @@ Example:
 #  limitations under the License.
 
 # ruff: noqa: UP001, UP010
-from __future__ import absolute_import, division, print_function
+from __future__ import absolute_import, annotations, division, print_function
 
 # pylint: disable-next=invalid-name
 __metaclass__ = type
@@ -191,7 +191,7 @@ if __name__ == "__main__":
     class MockQueue:
         """A mock queue for handling events asynchronously."""
 
-        async def put(self: "MockQueue", event: str) -> None:
+        async def put(self: MockQueue, event: str) -> None:
             """Put an event into the queue.
 
             Parameters
@@ -202,7 +202,7 @@ if __name__ == "__main__":
             """
             the_logger.info(event)
 
-        async def get(self: "MockQueue") -> None:
+        async def get(self: MockQueue) -> None:
             """Get an event from the queue."""
             the_logger.info("Getting event from the queue.")
 

--- a/extensions/eda/plugins/event_source/logs.py
+++ b/extensions/eda/plugins/event_source/logs.py
@@ -32,8 +32,8 @@ Example:
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-# ruff: noqa: UP001, UP010
-from __future__ import absolute_import, annotations, division, print_function
+# ruff: noqa: UP001, UP010, FA102
+from __future__ import absolute_import, division, print_function
 
 # pylint: disable-next=invalid-name
 __metaclass__ = type
@@ -191,7 +191,7 @@ if __name__ == "__main__":
     class MockQueue:
         """A mock queue for handling events asynchronously."""
 
-        async def put(self: MockQueue, event: str) -> None:
+        async def put(self: "MockQueue", event: str) -> None:
             """Put an event into the queue.
 
             Parameters
@@ -202,7 +202,7 @@ if __name__ == "__main__":
             """
             the_logger.info(event)
 
-        async def get(self: MockQueue) -> None:
+        async def get(self: "MockQueue") -> None:
             """Get an event from the queue."""
             the_logger.info("Getting event from the queue.")
 


### PR DESCRIPTION
## Description
Updated code for Red Hat's certification checks. Fixes failure of checks executed by `ruff` with `tox` for EDA code.
UPDATE: Fixes clashed with `ansible-sanity` checks, so were backed out per review with Ansible Partner Engineering, and instead a skip was put in for the ruff test `FA102`.

## Motivation and Context
The `tox` testing/linting tool required by Red Hat as part of EDA certification is not version pinned/ranged. The `ruff` tool (executed with `tox`) moved from 0.0.283 to 0.0.284, then we started to get new errors, with no changes to the code:
```
extensions/eda/plugins/event_source/logs.py:104:14: FA102 Missing `from __future__ import annotations`, but uses PEP 585 collection
extensions/eda/plugins/event_source/logs.py:106:6: FA102 Missing `from __future__ import annotations`, but uses PEP 585 collection
extensions/eda/plugins/event_source/logs.py:148:11: FA102 Missing `from __future__ import annotations`, but uses PEP 585 collection
```
The changes in this PR provide fixes for these errors and the subsequent cascading errors during local testing with `tox`.
UPDATE: Not a fix, but a skip, see above.

## How Has This Been Tested?
Tested locally

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.