### PR TITLE
Adding meta/extensions.yml file to display EDA on Automation Hub

### DIFF
--- a/meta/extensions.yml
+++ b/meta/extensions.yml
@@ -1,0 +1,5 @@
+extensions:
+  - args:
+      ext_dir: eda/plugins/event_filter
+  - args:
+      ext_dir: eda/plugins/event_source


### PR DESCRIPTION
## Description

Adding the `meta/extensions.yml` file, which is required to display EDA content in documentation on Automation Hub. This file points to the EDA plugin paths inside the collection. 

## Motivation and Context

Eventually, `ansible-doc` will use this file to display EDA plugins and list their full contents on Automation Hub, exactly like other Ansible plugins. This feature is in development. Currently, galaxy-importer directly consumes this file to display EDA plugins in Automation Hub. Without this file, EDA plugins are not listed in the collection's "content" list.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

This is the confirmed way to display EDA plugins on Automation Hub. All future EDA collections will be asked to include this file. 

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
