### PR TITLE
fix(panos_device_group): Do not move a Device Group if state is set to gathered

### DIFF
--- a/plugins/modules/panos_device_group.py
+++ b/plugins/modules/panos_device_group.py
@@ -112,7 +112,8 @@ class Helper(ConnectionHelper):
         else:
             parent = module.params["parent"]
             result["diff"]["after_parent"] = parent
-            if obj.opstate.dg_hierarchy.parent != parent:
+            if obj.opstate.dg_hierarchy.parent != parent \
+            and module.params["state"] != "gathered":
                 result["changed"] = True
                 obj.opstate.dg_hierarchy.parent = parent
                 if not module.check_mode:

--- a/plugins/modules/panos_device_group.py
+++ b/plugins/modules/panos_device_group.py
@@ -112,9 +112,10 @@ class Helper(ConnectionHelper):
         else:
             parent = module.params["parent"]
             result["diff"]["after_parent"] = parent
-            if (
-                obj.opstate.dg_hierarchy.parent != parent
-                and module.params["state"] != "gathered"
+            if obj.opstate.dg_hierarchy.parent != parent and module.params["state"] in (
+                "present",
+                "replaced",
+                "merged",
             ):
                 result["changed"] = True
                 obj.opstate.dg_hierarchy.parent = parent

--- a/plugins/modules/panos_device_group.py
+++ b/plugins/modules/panos_device_group.py
@@ -112,8 +112,10 @@ class Helper(ConnectionHelper):
         else:
             parent = module.params["parent"]
             result["diff"]["after_parent"] = parent
-            if obj.opstate.dg_hierarchy.parent != parent \
-            and module.params["state"] != "gathered":
+            if (
+                obj.opstate.dg_hierarchy.parent != parent
+                and module.params["state"] != "gathered"
+            ):
                 result["changed"] = True
                 obj.opstate.dg_hierarchy.parent = parent
                 if not module.check_mode:


### PR DESCRIPTION
## Description
Change logic in the Device Group module so the DG hierarchy is only refreshed/updated if the user inputs `state` as `present`, `merged` or `replaced`, and therefore by implication, not refreshed/updated when the user inputs `state` as `gathered`, per #464 

## Motivation and Context
Fixes #464 

## How Has This Been Tested?
Tested locally

## Screenshots (if appropriate)
Before and after testing:
![Screenshot 2023-09-01 at 12 37 28](https://github.com/PaloAltoNetworks/pan-os-ansible/assets/6574404/273cdb39-ffd1-45f0-b6b3-1b91d860ef9a)

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.