### PR TITLE
docs: More updates for support statements and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ factors, using the PAN-OS API.
 -   Free software: Apache 2.0 License
 -   Documentation:
     <https://paloaltonetworks.github.io/pan-os-ansible/>
--   PANW community supported live page:
-    <http://live.paloaltonetworks.com/ansible>
+-   Getting started tutorials, how-to guides and other background reading:
+    <https://pan.dev/ansible/docs/panos>
 -   Repo:
     <https://github.com/PaloAltoNetworks/pan-os-ansible>
 -   Example Playbooks:

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -13,3 +13,8 @@ itself. Unless explicitly tagged, all projects or work posted in our GitHub
 repository (at https://github.com/PaloAltoNetworks) or sites other than our
 official Downloads page on https://support.paloaltonetworks.com are provided
 under the best effort policy.
+
+As of version 2.12.2, this Collection of Ansible Modules for PAN-OS is
+[certified on Ansible Automation Hub](https://console.redhat.com/ansible/automation-hub/repo/published/paloaltonetworks/panos)
+and officially supported for Ansible subscribers. Ansible subscribers can engage
+for support through their usual route towards Red Hat.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -10,8 +10,9 @@ Generation Firewalls (both physical and virtualized) and Panorama.  The
 underlying protocol uses API calls that are wrapped within the Ansible
 framework.
 
-This is a **community supported project**. You can find the community
-supported live page at https://live.paloaltonetworks.com/ansible.
+This is the module reference documentation. Other documentation including
+getting started tutorials, how-to guides and other background reading, can
+be found at https://pan.dev/ansible/docs/panos/
 
 
 Installation
@@ -37,6 +38,7 @@ Then in your playbooks you can specify that you want to use the
         - paloaltonetworks.panos
 
 * Ansible Galaxy: https://galaxy.ansible.com/PaloAltoNetworks/panos
+* Red Hat Catalog: https://catalog.redhat.com/software/collection/paloaltonetworks/panos
 * GitHub repo:  https://github.com/PaloAltoNetworks/pan-os-ansible
 
 


### PR DESCRIPTION
## Description
- Updating support statements in various places, to reflect official support for Ansible subscribers, community support for others.
- Updating links to live.paloaltonetworks.com to be pan.dev instead

## Motivation and Context
- Some support statements gave a visual interpretation that only community support was available
- The developer presence is moving from live.paloaltonetworks.com to focus on pan.dev

## How Has This Been Tested?
N/A

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.