### PR TITLE
fix(panos_export): Fix create_directory for panos_export for binary files

### DIFF
--- a/plugins/modules/panos_export.py
+++ b/plugins/modules/panos_export.py
@@ -263,7 +263,6 @@ def export_binary(module, xapi, category, filename, create_directory):
 
 
 def save_binary(module, xapi, category, filename, create_directory):
-
     # This function is almost the same as export_binary, but omits the line...
     #   xapi.export(category=category)
     # This function is therefore used where the xapi.export operation is already done
@@ -284,8 +283,9 @@ def save_binary(module, xapi, category, filename, create_directory):
         module.fail_json(msg=msg)
 
 
-def export_async(module, xapi, category, filename, interval=60, timeout=600):
-
+def export_async(
+    module, xapi, category, filename, interval=60, timeout=600, create_directory=False
+):
     # Submit job, get resulting job id
     xapi.export(category=category)
     job_result = ET.fromstring(xapi.xml_root())
@@ -313,7 +313,7 @@ def export_async(module, xapi, category, filename, interval=60, timeout=600):
     # Get completed job
     xapi.export(category=category, extra_qs={"action": "get", "job-id": job_id})
 
-    save_binary(module, xapi, category, filename)
+    save_binary(module, xapi, category, filename, create_directory)
 
 
 HTML_EXPORTS = [
@@ -407,7 +407,14 @@ def main():
         if category == "stats-dump" and isinstance(parent, Panorama):
             module.fail_json(msg="stats-dump is not supported on Panorama")
 
-        export_async(module, xapi, category, filename, timeout=timeout)
+        export_async(
+            module,
+            xapi,
+            category,
+            filename,
+            timeout=timeout,
+            create_directory=create_directory,
+        )
 
     elif category == "device-state":
         if filename is None:
@@ -442,7 +449,6 @@ def main():
         save_binary(module, xapi, category, filename, create_directory)
 
     elif category == "application-pcap":
-
         # When exporting an application pcap, from_name can be:
         #   - nothing, which gets you a list of directories
         #   - a directory name, which gets you a list of pcaps in that directory
@@ -464,7 +470,6 @@ def main():
             save_binary(module, xapi, category, filename)
 
     elif category == "filter-pcap":
-
         # When exporting a filter pcap, from_name can be:
         #   - nothing, which gets you a list of files
         #   - a filename, which gets you the pcap file

--- a/plugins/modules/panos_export.py
+++ b/plugins/modules/panos_export.py
@@ -467,7 +467,7 @@ def main():
             if filename is None:
                 module.fail_json(msg="filename is required for export")
 
-            save_binary(module, xapi, category, filename)
+            save_binary(module, xapi, category, filename, create_directory)
 
     elif category == "filter-pcap":
         # When exporting a filter pcap, from_name can be:
@@ -487,7 +487,7 @@ def main():
             if filename is None:
                 module.fail_json(msg="filename is required for export")
 
-            save_binary(module, xapi, category, filename)
+            save_binary(module, xapi, category, filename, create_directory)
 
     elif category == "dlp-pcap":
         from_name = module.params["dlp_pcap_name"]
@@ -512,7 +512,7 @@ def main():
             if filename is None:
                 module.fail_json(msg="filename is required for export")
 
-            save_binary(module, xapi, category, filename)
+            save_binary(module, xapi, category, filename, create_directory)
 
     elif category == "threat-pcap":
         if filename is None:
@@ -535,7 +535,7 @@ def main():
             search_time=search_time,
             serialno=serial,
         )
-        save_binary(module, xapi, category, filename)
+        save_binary(module, xapi, category, filename, create_directory)
 
     module.exit_json(changed=False)
 


### PR DESCRIPTION
## Description
Fixes an issue where `create_directory` for `save_binary` is used by a playbook using `category: "stats-dump"` and the parameter `create_directory` is not defined.

## Motivation and Context
Issue was found during integration testing for other areas of the code

## How Has This Been Tested?
Tested locally with:
```
    - name: Download statsdump
      paloaltonetworks.panos.panos_export:
        provider: "{{ device }}"
        category: "stats-dump"
        filename: "statsdump.tar.gz"
```

## Screenshots (if appropriate)
Error found before applying this PR's fix:
![Screenshot 2023-09-18 at 13 11 34](https://github.com/PaloAltoNetworks/pan-os-ansible/assets/6574404/fef6dc77-6f8e-4513-84a5-96d18395ae42)
After applying this PR's fix:
![Screenshot 2023-09-18 at 13 25 45](https://github.com/PaloAltoNetworks/pan-os-ansible/assets/6574404/6e09958a-49fc-4699-a268-7d4c6de0e3a1)

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.