### PR TITLE
fix(various): Remove unused imports for pylint testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ old-sanity:		## Sanity tests for Ansible v2.9 and Ansible v2.10
 
 .PHONY: new-sanity
 new-sanity:		## Sanity tests for Ansible v2.11 and above
-	ansible-test sanity -v --skip-test pylint --python $(python_version)
+	ansible-test sanity -v --python $(python_version)
 
 .PHONY: reqs
 reqs:       ## Recreate the requirements.txt file

--- a/plugins/module_utils/panos.py
+++ b/plugins/module_utils/panos.py
@@ -37,7 +37,7 @@ from functools import reduce
 import importlib
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.connection import Connection, ConnectionError
+from ansible.module_utils.connection import Connection
 
 _MIN_VERSION_ERROR = "{0} version ({1}) < minimum version ({2})"
 HAS_PANDEVICE = True

--- a/plugins/modules/panos_export.py
+++ b/plugins/modules/panos_export.py
@@ -199,17 +199,14 @@ from ansible_collections.paloaltonetworks.panos.plugins.module_utils.panos impor
 )
 
 try:
-    from panos.errors import PanDeviceError
     from panos.panorama import Panorama
 except ImportError:
     try:
-        from pandevice.errors import PanDeviceError
         from pandevice.panorama import Panorama
     except ImportError:
         pass
 
 try:
-    import pan.xapi
     import xmltodict
 
     HAS_LIB = True
@@ -217,7 +214,6 @@ except ImportError:
     HAS_LIB = False
 
 import json
-import os
 import pathlib
 import time
 import xml.etree.ElementTree as ET

--- a/plugins/modules/panos_facts.py
+++ b/plugins/modules/panos_facts.py
@@ -233,7 +233,6 @@ from ansible_collections.paloaltonetworks.panos.plugins.module_utils.panos impor
 
 try:
     from panos.device import Vsys
-    from panos.errors import PanDeviceError
     from panos.firewall import Firewall
     from panos.network import (
         AggregateInterface,
@@ -251,7 +250,6 @@ try:
 except ImportError:
     try:
         from pandevice.device import Vsys
-        from pandevice.errors import PanDeviceError
         from pandevice.firewall import Firewall
         from pandevice.network import (
             AggregateInterface,

--- a/plugins/modules/panos_import.py
+++ b/plugins/modules/panos_import.py
@@ -205,9 +205,7 @@ from ansible_collections.paloaltonetworks.panos.plugins.module_utils.panos impor
 )
 
 try:
-    import pan.xapi
     import requests
-    import requests_toolbelt
 
     HAS_LIB = True
 except ImportError:

--- a/plugins/modules/panos_object.py
+++ b/plugins/modules/panos_object.py
@@ -256,16 +256,15 @@ RETURN = """
 from ansible.module_utils.basic import AnsibleModule
 
 try:
-    import panos
     from panos.panorama import DeviceGroup
-    from panos import objects, panorama
+    from panos import objects
     from panos.base import PanDevice
     from panos.errors import PanDeviceError
 except ImportError:
     try:
         import pandevice
         from pandevice.panorama import DeviceGroup
-        from pandevice import objects, panorama
+        from pandevice import objects
         from pandevice.base import PanDevice
         from pandevice.errors import PanDeviceError
     except ImportError:

--- a/plugins/modules/panos_object.py
+++ b/plugins/modules/panos_object.py
@@ -293,10 +293,10 @@ def get_devicegroup(device, devicegroup):
 def find_object(device, dev_group, obj_name, obj_type):
     # Get the firewall objects
     obj_type.refreshall(device)
-    if isinstance(device, pandevice.firewall.Firewall):
+    if isinstance(device, firewall.Firewall):
         addr = device.find(obj_name, obj_type)
         return addr
-    elif isinstance(device, pandevice.panorama.Panorama):
+    elif isinstance(device, panorama.Panorama):
         addr = device.find(obj_name, obj_type)
         if addr is None:
             if dev_group:

--- a/plugins/modules/panos_object.py
+++ b/plugins/modules/panos_object.py
@@ -256,14 +256,16 @@ RETURN = """
 from ansible.module_utils.basic import AnsibleModule
 
 try:
-    from panos.panorama import DeviceGroup
+    from panos.panorama import DeviceGroup, Panorama
+    from panos.firewall import Firewall
     from panos import objects
     from panos.base import PanDevice
     from panos.errors import PanDeviceError
 except ImportError:
     try:
         import pandevice
-        from pandevice.panorama import DeviceGroup
+        from pandevice.panorama import DeviceGroup, Panorama
+        from pandevice.firewall import Firewall
         from pandevice import objects
         from pandevice.base import PanDevice
         from pandevice.errors import PanDeviceError
@@ -293,10 +295,10 @@ def get_devicegroup(device, devicegroup):
 def find_object(device, dev_group, obj_name, obj_type):
     # Get the firewall objects
     obj_type.refreshall(device)
-    if isinstance(device, firewall.Firewall):
+    if isinstance(device, Firewall):
         addr = device.find(obj_name, obj_type)
         return addr
-    elif isinstance(device, panorama.Panorama):
+    elif isinstance(device, Panorama):
         addr = device.find(obj_name, obj_type)
         if addr is None:
             if dev_group:

--- a/plugins/modules/panos_object.py
+++ b/plugins/modules/panos_object.py
@@ -263,7 +263,6 @@ try:
     from panos.errors import PanDeviceError
 except ImportError:
     try:
-        import pandevice
         from pandevice.panorama import DeviceGroup, Panorama
         from pandevice.firewall import Firewall
         from pandevice import objects

--- a/plugins/modules/panos_query_rules.py
+++ b/plugins/modules/panos_query_rules.py
@@ -150,7 +150,6 @@ try:
     from panos import base, firewall, objects, panorama, policies
 except ImportError:
     try:
-        import pandevice
         from pandevice import base, firewall, objects, panorama, policies
     except ImportError:
         pass
@@ -203,7 +202,7 @@ def get_object(device, dev_group, obj_name):
         return match
 
     # Search Panorama device group
-    if isinstance(device, pandevice.panorama.Panorama):
+    if isinstance(device, panorama.Panorama):
         # Search device group address objects
         match = dev_group.find(obj_name, objects.AddressObject)
         if match:
@@ -247,7 +246,7 @@ def get_services(device, dev_group, svc_list, obj_list):
             get_services(device, dev_group, global_grp_match.value, obj_list)
 
         # Search Panorama device group
-        if isinstance(device, pandevice.panorama.Panorama):
+        if isinstance(device, panorama.Panorama):
 
             # Search device group address objects
             dg_obj_match = dev_group.find(svc, objects.ServiceObject)

--- a/plugins/modules/panos_query_rules.py
+++ b/plugins/modules/panos_query_rules.py
@@ -147,7 +147,6 @@ RETURN = """
 from ansible.module_utils.basic import AnsibleModule
 
 try:
-    import panos
     from panos import base, firewall, objects, panorama, policies
 except ImportError:
     try:

--- a/plugins/modules/panos_redistribution.py
+++ b/plugins/modules/panos_redistribution.py
@@ -136,22 +136,6 @@ from ansible_collections.paloaltonetworks.panos.plugins.module_utils.panos impor
     get_connection,
 )
 
-try:
-    from panos.network import (
-        RedistributionProfile,
-        RedistributionProfileIPv6,
-        VirtualRouter,
-    )
-except ImportError:
-    try:
-        from pandevice.network import (
-            RedistributionProfile,
-            RedistributionProfileIPv6,
-            VirtualRouter,
-        )
-    except ImportError:
-        pass
-
 
 class Helper(ConnectionHelper):
     def spec_handling(self, spec, module):

--- a/tests/unit/httpapi/test_panos.py
+++ b/tests/unit/httpapi/test_panos.py
@@ -9,7 +9,6 @@ import pytest
 from ansible.module_utils.basic import to_text
 from ansible.module_utils.six import BytesIO
 from ansible.module_utils.six.moves import urllib
-from ansible.module_utils.six.moves.urllib.error import HTTPError
 from ansible_collections.mrichardson03.panos.plugins.httpapi.panos import (
     HttpApi,
     PanOSAPIError,

--- a/tests/unit/plugins/module_utils/test_panos.py
+++ b/tests/unit/plugins/module_utils/test_panos.py
@@ -17,12 +17,11 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-from unittest.mock import MagicMock, Mock, PropertyMock, patch
+from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.paloaltonetworks.panos.plugins.module_utils.panos import (
-    ConnectionHelper,
     get_connection,
 )
 


### PR DESCRIPTION
## Description
Remove unused imports to pass pylint testing.
Remove `skip` for pylint testing in CI.

## Motivation and Context
Fixes #490

## How Has This Been Tested?
Tested locally with integration tests in this repo

## Screenshots (if appropriate)
Before changes:
![Screenshot 2023-09-19 at 13 26 04](https://github.com/PaloAltoNetworks/pan-os-ansible/assets/6574404/985cc36a-dc66-499c-889c-4ce0c1ea65f7)

After changes:
![Screenshot 2023-09-19 at 16 38 38](https://github.com/PaloAltoNetworks/pan-os-ansible/assets/6574404/d2478bfe-41fc-42e0-8812-a35d4cdf0ed0)

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.