### PR TITLE
chore: Update required Ansible version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - ansible: "2.13"
-            python_ver: "3.10"
           - ansible: "2.14"
             python_ver: "3.11"
           - ansible: "2.15"
@@ -220,7 +218,7 @@ jobs:
         uses: Gr1N/setup-poetry@v8
 
       - name: Add ansible-core
-        run: poetry add ansible-core^2.13
+        run: poetry add ansible-core^2.14
 
       - name: Add antsibull-docs
         run: poetry add antsibull-docs^1.11.0

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,5 +1,5 @@
 ---
-requires_ansible: '>=2.12.0'
+requires_ansible: '>=2.14.0'
 plugin_routing:
   modules:
     panos_admin:

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,5 +1,5 @@
 ---
-requires_ansible: '>=2.13.0'
+requires_ansible: '>=2.12.0'
 plugin_routing:
   modules:
     panos_admin:


### PR DESCRIPTION
## Description

In CI workflow action for Ansible linter is used, which was recently updated (https://github.com/ansible/ansible-lint/commit/cba7c512bb94a2ad36109f20358475ae18c88bc6) and requires now Ansible in version `2.14.0, <2.16`.

In PR beside change of required Ansible version, there were removed sanity tests on Ansible 2.13 and using `ansible-core^2.14` in CI workflow steps.

## Motivation and Context

CI workflow stopped to work.

Moreover Ansible 2.13 is EOL (https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix).

## How Has This Been Tested?

Code was tested by running workflow.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
