### PR TITLE
fix: define in pyproject.toml Python 3.9 for ansible-core 2.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,12 @@ Tested Ansible Versions
 -----------------------
 
 This collection is tested with the most current Ansible releases.  Ansible versions
-before 2.9.10 are **not supported**.
+before 2.14 are **not supported**.
 
 Python Version
 --------------
 
-The minimum python version for this collection is python 3.8.
+The minimum python version for this collection is python 3.9.
 
 Installation
 ------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/PaloAltoNetworks/pan-os-ansible"
 repository = "https://github.com/PaloAltoNetworks/pan-os-ansible"
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "^3.9"
 pan-python = "^0.17.0"
 pan-os-python = "^1.8.0"
 xmltodict = "^0.12.0"


### PR DESCRIPTION
## Description

According to https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix, minimum version of Python for `ansible-core 2.14` is `Python 3.9`.

## Motivation and Context

Release action failed on step for documentation: https://github.com/PaloAltoNetworks/pan-os-ansible/actions/runs/7194066471/job/19593939780#step:5:108

## How Has This Been Tested?

Code was checked locally by command: `poetry add ansible-core^2.14`

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist


- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
