### PR TITLE
Rzfeeser patch 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ Install this collection using the Ansible Galaxy CLI:
 ansible-galaxy collection install paloaltonetworks.panos
 ```
 
+Install the collection's python dependencies using the Python pip installer and the `requirements.txt` file found in the root of this repository:
+
+```bash
+pip install -r requirements.txt
+```
+
 Usage
 -----
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,7 @@ xmltodict==0.12.0 ; python_version >= "3.8" and python_version < "4.0" \
 panos-upgrade-assurance==0.3.0 ; python_version >= "3.8" and python_version < "4.0" \
     --hash=sha256:0e5bb1a1f5bf317086fe118fb80f5d03c1aa1426c8ecdcda657983f392accc63 \
     --hash=sha256:88bfc470f9bfa09ed22c919f8328782868c649d44e97a06c8d29c32e0211c257
+pyopenssl==23.3.0 ; python_version > "3.8" and python_version < "4.0" \
+    --hash=sha256:6756834481d9ed5470f4a9393455154bc92fe7a64b7bc6ee2c804e78c52099b2
+cryptography==41.0.7 ; python_version > "3.8" and python_version < "4.0" \
+    --hash=sha256:43f2552a2378b44869fe8827aa19e69512e3245a219104438692385b0ee119d1

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,0 +1,3 @@
+---
+collections:
+  - paloaltonetworks.panos


### PR DESCRIPTION
## Description

Updated `requirements.txt` in the root of the repo to include entries and hashes for `cryptography` and `pyopenssl`. These are dependencies of `panos-upgrade-assurance`. Attempting to use the previous requirements file would fail as it would attempt to install `cryptography` and `pyopenssl`, and find no entry for these libraries or their hashes. In hash mode, pip is very clear that all installed packages must have hashes.

The file `requirements.yml` was also added. This file documents any and all Ansible collections this collection depends on. Even mention of itself is important for using Dockerfile or ansible-builder to create stable execution spaces.

Tested using a fresh install of Ubuntu 22.04 LTS, `ansible [core 2.16.1]`, `python version = 3.10.12`, and `jinja version = 3.0.3`. Was able to successfuly run the `panos_facts` module against panos_VM.

Updated README.md to include instructions on how to use requirements.txt with pip.

## Motivation and Context

Previously, attempting to use `requirements.txt` with pip would fail. For the purposes of a creating a stable Ansible environment for running playbooks, it is necessary to correctly document `requirements.txt` so that it may be used in conjunctions with Dockerfile or ansible-builder to create a container space for execution purposes.

The file `requirements.yml` was also added. This file documents any and all Ansible collections this collection depends on. Even mention of `paloaltonetwork.panos` is important for using Dockerfile or ansible-builder to create stable execution spaces.

Literature regarding proper documentation of dependencies in Ansible may be found at the following:
 [https://ansible.readthedocs.io/projects/builder/en/stable/collection_metadata/](https://ansible.readthedocs.io/projects/builder/en/stable/collection_metadata/)

## How Has This Been Tested?

Tested using a fresh install of Ubuntu 22.04 LTS, `ansible [core 2.16.1]`, `python version = 3.10.12`, and `jinja version = 3.0.3`. Was able to successfully run the `panos_facts` module against panos_VM.

The command `ansible-test sanity --local` is also still passing, however, no changes made by this commit would cause it to fail. This is mostly documentation and version control stability.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes if appropriate.
- [X] All new and existing tests passed.
