### PR TITLE
fix(panos_check): account for failed jobs

### DIFF
--- a/plugins/modules/panos_check.py
+++ b/plugins/modules/panos_check.py
@@ -102,7 +102,7 @@ def check_jobs(jobs):
         job_type = j.findtext(".//type")
         job_result = j.findtext(".//result")
 
-        if job_type is None and job_result == "Failed-Job":
+        if job_type == "Failed-Job" and job_result is None:
             return True
 
         if job_type is None or job_result is None:

--- a/plugins/modules/panos_check.py
+++ b/plugins/modules/panos_check.py
@@ -102,6 +102,9 @@ def check_jobs(jobs):
         job_type = j.findtext(".//type")
         job_result = j.findtext(".//result")
 
+        if job_type is None and job_result == "Failed-Job":
+            return True
+
         if job_type is None or job_result is None:
             return False
 


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
The panos_check checks for jobs that aren't complete. It treats jobs with job_type is None or job_result is None as not complete.
But jobs that are failed can have a missing job_result and a job_type == 'Failed-Job'. 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Failed jobs should be considered complete for the purpose of panos-check.
Fixes #533 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I had a playbook that included panos_check that timed out because there were failed jobs. 
After making the change it returns.

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)
## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
