### PR TITLE
docs: fix eda ruff docs linting

### DIFF
--- a/extensions/eda/plugins/event_source/logs.py
+++ b/extensions/eda/plugins/event_source/logs.py
@@ -59,6 +59,7 @@ async def status() -> web.Response:
     Returns
     -------
     A web.Response object with status 200 and the text "up" returned by the function.
+
     """
     return web.Response(status=200, text="up")
 
@@ -78,6 +79,7 @@ async def webhook(request: web.Request) -> web.Response:
     Returns
     -------
     A web.Response object with status 200 and the status.
+
     """
     try:
         payload = await request.json()


### PR DESCRIPTION
## Description

Tox ruff checks in CI for EDA partner testing was failing due to required linting. This PR fixes the below error for this check to pass.

## Motivation and Context

ruff checks was failing because of a blank line required after "Returns" section in docstrings.

```
ruff: commands[0]> ruff check --select ALL --ignore INP001 -q ../../extensions/eda/plugins
/home/runner/work/pan-os-ansible/pan-os-ansible/extensions/eda/plugins/event_source/logs.py:57:5: D413 [*] Missing blank line after last section ("Returns")
/home/runner/work/pan-os-ansible/pan-os-ansible/extensions/eda/plugins/event_source/logs.py:68:5: D413 [*] Missing blank line after last section ("Returns")
ruff: exit 1 (0.01 seconds) /home/runner/work/pan-os-ansible/pan-os-ansible/.github/workflows> ruff check --select ALL --ignore INP001 -q ../../extensions/eda/plugins pid=[18](https://github.com/PaloAltoNetworks/pan-os-ansible/actions/runs/7958993848/job/21725025183#step:4:19)35
ruff: FAIL ✖ in 2 seconds
```

## How Has This Been Tested?

Tested locally with tox and on CI.

## Types of changes

CI tox fix.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
