### PR TITLE
fix: Add 'parent_interface' parameter for l2/l3 subinterface modules

### DIFF
--- a/extensions/eda/plugins/event_source/logs.py
+++ b/extensions/eda/plugins/event_source/logs.py
@@ -59,6 +59,7 @@ async def status() -> web.Response:
     Returns
     -------
     A web.Response object with status 200 and the text "up" returned by the function.
+
     """
     return web.Response(status=200, text="up")
 
@@ -78,6 +79,7 @@ async def webhook(request: web.Request) -> web.Response:
     Returns
     -------
     A web.Response object with status 200 and the status.
+
     """
     try:
         payload = await request.json()

--- a/tests/integration/firewall/test_panos_l2_subinterface.yml
+++ b/tests/integration/firewall/test_panos_l2_subinterface.yml
@@ -1,0 +1,105 @@
+---
+- name: test_panos_l2_subinterface - Create
+  paloaltonetworks.panos.panos_l2_subinterface:
+    provider: '{{ device }}'
+    name: 'ethernet1/1.1'
+    tag: 2
+  register: result
+
+- name: test_panos_l2_subinterface - Assert create was successful
+  assert:
+    that:
+      - result is success
+      - result is changed
+
+- name: test_panos_l2_subinterface - Create (idempotence)
+  paloaltonetworks.panos.panos_l2_subinterface:
+    provider: '{{ device }}'
+    name: 'ethernet1/1.1'
+    tag: 2
+  register: result
+
+- name: test_panos_l2_subinterface - Assert create (idempotence) was successful
+  assert:
+    that:
+      - result is success
+      - result is not changed
+
+- name: test_panos_l2_subinterface - Modify
+  paloaltonetworks.panos.panos_l2_subinterface:
+    provider: '{{ device }}'
+    name: 'ethernet1/1.1'
+    tag: 1
+  register: result
+
+- name: test_panos_l2_subinterface - Assert modify was successful
+  assert:
+    that:
+      - result is success
+      - result is changed
+
+- name: test_panos_l2_subinterface - Gather all
+  paloaltonetworks.panos.panos_l2_subinterface:
+    provider: '{{ device }}'
+    parent_interface: 'ethernet1/1'
+    state: 'gathered'
+    gathered_filter: '*'
+  register: result
+
+- name: test_panos_l2_subinterface - Assert gather all returned result
+  assert:
+    that:
+      - result is success
+      - "{{ result.gathered | length == 1 }}"
+
+- name: test_panos_l2_subinterface - Gather by parameter with one match
+  paloaltonetworks.panos.panos_l2_subinterface:
+    provider: '{{ device }}'
+    parent_interface: 'ethernet1/1'
+    state: 'gathered'
+    gathered_filter: 'name ends-with 1'
+  register: result
+
+- name: test_panos_l2_subinterface - Assert gather by parameter with one match returned result
+  assert:
+    that:
+      - result is success
+      - "{{ result.gathered | length == 1 }}"
+
+- name: test_panos_l2_subinterface - Gather by parameter with no match
+  paloaltonetworks.panos.panos_l2_subinterface:
+    provider: '{{ device }}'
+    parent_interface: 'ethernet1/1'
+    state: 'gathered'
+    gathered_filter: 'name ends-with 2'
+  register: result
+
+- name: test_panos_l2_subinterface - Assert gather by parameter with no match returned result
+  assert:
+    that:
+      - result is success
+      - "{{ result.gathered | length == 0 }}"
+
+- name: test_panos_l2_subinterface - Delete
+  paloaltonetworks.panos.panos_l2_subinterface:
+    provider: '{{ device }}'
+    name: 'ethernet1/1.1'
+    tag: 2
+    state: 'absent'
+  register: result
+
+- name: test_panos_l2_subinterface - Assert delete was successful
+  assert:
+    that:
+      - result is success
+      - result is changed
+
+- name: test_panos_l2_subinterface - Make sure changes commit cleanly
+  paloaltonetworks.panos.panos_commit_firewall:
+    provider: '{{ device }}'
+  register: result
+
+- name: test_panos_l2_subinterface - Assert commit was successful
+  assert:
+    that:
+      - result is success

--- a/tests/integration/firewall/test_panos_l3_subinterface.yml
+++ b/tests/integration/firewall/test_panos_l3_subinterface.yml
@@ -1,0 +1,105 @@
+---
+- name: test_panos_l3_subinterface - Create
+  paloaltonetworks.panos.panos_l3_subinterface:
+    provider: '{{ device }}'
+    name: 'ethernet1/1.1'
+    tag: 2
+  register: result
+
+- name: test_panos_l3_subinterface - Assert create was successful
+  assert:
+    that:
+      - result is success
+      - result is changed
+
+- name: test_panos_l3_subinterface - Create (idempotence)
+  paloaltonetworks.panos.panos_l3_subinterface:
+    provider: '{{ device }}'
+    name: 'ethernet1/1.1'
+    tag: 2
+  register: result
+
+- name: test_panos_l3_subinterface - Assert create (idempotence) was successful
+  assert:
+    that:
+      - result is success
+      - result is not changed
+
+- name: test_panos_l3_subinterface - Modify
+  paloaltonetworks.panos.panos_l3_subinterface:
+    provider: '{{ device }}'
+    name: 'ethernet1/1.1'
+    tag: 1
+  register: result
+
+- name: test_panos_l3_subinterface - Assert modify was successful
+  assert:
+    that:
+      - result is success
+      - result is changed
+
+- name: test_panos_l3_subinterface - Gather all
+  paloaltonetworks.panos.panos_l3_subinterface:
+    provider: '{{ device }}'
+    parent_interface: 'ethernet1/1'
+    state: 'gathered'
+    gathered_filter: '*'
+  register: result
+
+- name: test_panos_l3_subinterface - Assert gather all returned result
+  assert:
+    that:
+      - result is success
+      - "{{ result.gathered | length == 1 }}"
+
+- name: test_panos_l3_subinterface - Gather by parameter with one match
+  paloaltonetworks.panos.panos_l3_subinterface:
+    provider: '{{ device }}'
+    parent_interface: 'ethernet1/1'
+    state: 'gathered'
+    gathered_filter: 'name ends-with 1'
+  register: result
+
+- name: test_panos_l3_subinterface - Assert gather by parameter with one match returned result
+  assert:
+    that:
+      - result is success
+      - "{{ result.gathered | length == 1 }}"
+
+- name: test_panos_l3_subinterface - Gather by parameter with no match
+  paloaltonetworks.panos.panos_l3_subinterface:
+    provider: '{{ device }}'
+    parent_interface: 'ethernet1/1'
+    state: 'gathered'
+    gathered_filter: 'name ends-with 2'
+  register: result
+
+- name: test_panos_l3_subinterface - Assert gather by parameter with no match returned result
+  assert:
+    that:
+      - result is success
+      - "{{ result.gathered | length == 0 }}"
+
+- name: test_panos_l3_subinterface - Delete
+  paloaltonetworks.panos.panos_l3_subinterface:
+    provider: '{{ device }}'
+    name: 'ethernet1/1.1'
+    tag: 2
+    state: 'absent'
+  register: result
+
+- name: test_panos_l3_subinterface - Assert delete was successful
+  assert:
+    that:
+      - result is success
+      - result is changed
+
+- name: test_panos_l3_subinterface - Make sure changes commit cleanly
+  paloaltonetworks.panos.panos_commit_firewall:
+    provider: '{{ device }}'
+  register: result
+
+- name: test_panos_l3_subinterface - Assert commit was successful
+  assert:
+    that:
+      - result is success


### PR DESCRIPTION
## Description

Add new `parent_interface` parameter for `panos_l2_subinterface` and `panos_l3_subinterface` modules. The parameter is optional, except for case when state is set to `gathered`.

So far the parent interface has only been derived from subinterface name. This does not work with gathered state - for example when filter is based on the subinterface name - if it's not provided as a param, modules will fail (see linked issue).

## Motivation and Context

Resolves #498 

## How Has This Been Tested?

Tested locally as well as using newly added integration tests.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
