### PR TITLE
docs: fix custom url category "name" parameter description

### DIFF
--- a/plugins/modules/panos_custom_url_category.py
+++ b/plugins/modules/panos_custom_url_category.py
@@ -42,7 +42,7 @@ extends_documentation_fragment:
 options:
     name:
         description:
-            - Name of the tag.
+            - Name of the url category.
         type: str
     description:
         description:


### PR DESCRIPTION
## Description

Fix for `name` parameter description in `panos_custom_url_category` module.

## Motivation and Context

bugfix

## How Has This Been Tested?

n/a

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
