### PR TITLE
docs: replaced pan-os-upgrade-assurance with panos-upgrade-assurance

### DIFF
--- a/plugins/modules/panos_active_in_ha.py
+++ b/plugins/modules/panos_active_in_ha.py
@@ -33,7 +33,7 @@ version_added: '2.18.0'
 requirements:
     - pan-python can be obtained from PyPI U(https://pypi.python.org/pypi/pan-python)
     - pandevice can be obtained from PyPI U(https://pypi.python.org/pypi/pandevice)
-    - pan-os-upgrade-assurance can be obtained from PyPI U(https://pypi.org/project/panos-upgrade-assurance)
+    - panos-upgrade-assurance can be obtained from PyPI U(https://pypi.org/project/panos-upgrade-assurance)
 notes:
     - Panorama is not supported.
     - Check mode is not supported.

--- a/plugins/modules/panos_readiness_checks.py
+++ b/plugins/modules/panos_readiness_checks.py
@@ -35,7 +35,7 @@ version_added: '2.18.0'
 requirements:
     - pan-python can be obtained from PyPI U(https://pypi.python.org/pypi/pan-python)
     - pandevice can be obtained from PyPI U(https://pypi.python.org/pypi/pandevice)
-    - pan-os-upgrade-assurance can be obtained from PyPI U(https://pypi.org/project/panos-upgrade-assurance)
+    - panos-upgrade-assurance can be obtained from PyPI U(https://pypi.org/project/panos-upgrade-assurance)
 notes:
     - Panorama is not supported.
     - Check mode is not supported.

--- a/plugins/modules/panos_snapshot_report.py
+++ b/plugins/modules/panos_snapshot_report.py
@@ -38,7 +38,7 @@ version_added: '2.18.0'
 requirements:
     - pan-python can be obtained from PyPI U(https://pypi.python.org/pypi/pan-python)
     - pandevice can be obtained from PyPI U(https://pypi.python.org/pypi/pandevice)
-    - pan-os-upgrade-assurance can be obtained from PyPI U(https://pypi.python.org/pypi/pan-os-upgrade-assurance)
+    - panos-upgrade-assurance can be obtained from PyPI U(https://pypi.python.org/pypi/panos-upgrade-assurance)
 notes:
     - This is an offline module, no device connection is made.
     - Check mode is not supported.

--- a/plugins/modules/panos_state_snapshot.py
+++ b/plugins/modules/panos_state_snapshot.py
@@ -35,7 +35,7 @@ version_added: '2.18.0'
 requirements:
     - pan-python can be obtained from PyPI U(https://pypi.python.org/pypi/pan-python)
     - pandevice can be obtained from PyPI U(https://pypi.python.org/pypi/pandevice)
-    - pan-os-upgrade-assurance can be obtained from PyPI U(https://pypi.python.org/pypi/pan-os-upgrade-assurance)
+    - panos-upgrade-assurance can be obtained from PyPI U(https://pypi.python.org/pypi/panos-upgrade-assurance)
 notes:
     - Panorama is not supported.
     - Check mode is not supported.


### PR DESCRIPTION
## Description

Some links in the documentation had a typo for panos-upgrade-assurance

## Motivation and Context

Prevent somone installing a wrong package

## How Has This Been Tested?

only docs changed


## Types of changes

docs

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
