### PR TITLE
fix(panos_facts.py): Fixed virtual systems fact name

### DIFF
--- a/plugins/modules/panos_facts.py
+++ b/plugins/modules/panos_facts.py
@@ -483,7 +483,7 @@ class VsysFacts(Factbase):
                 }
             )
 
-        self.facts.update({"virtual-systems": virtual_systems})
+        self.facts.update({"virtual_systems": virtual_systems})
 
 
 class Config(Factbase):


### PR DESCRIPTION
## Description

This PR fixes #532 .

## Motivation and Context

Wrong fact name.

## How Has This Been Tested?

Local library and test file:

```yaml
TASK [Print vsys facts] ****************************************************************************
ok: [panorama-mgmt-main] => {
    "vsys": {
        "ansible_facts": {
            "ansible_net_full_commit_required": false,
            "ansible_net_gather_subset": [
                "system",
                "vsys"
            ],
            "ansible_net_hostname": "vma-test",
            "ansible_net_model": "PA-VM",
            "ansible_net_multivsys": "off",
            "ansible_net_serial": "",
            "ansible_net_uncommitted_changes": false,
            "ansible_net_uptime": "0 days, 4:38:10",
            "ansible_net_version": "11.1.0",
            "ansible_net_virtual_systems": [
                {
                    "vsys_currentsessions": "3",
                    "vsys_description": null,
                    "vsys_id": "1",
                    "vsys_iflist": [
                        "ethernet1/1",
                        "ethernet1/2"
                    ],
                    "vsys_maxsessions": "0",
                    "vsys_name": "vsys1",
                    "vsys_vrlist": [],
                    "vsys_zonelist": [
                        "some-zone"
                    ]
                }
            ]
        },
        "changed": false,
        "failed": false
    }
}
```

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
