### PR TITLE
feat: Add new option to panos_active_in_ha module

### DIFF
--- a/plugins/modules/panos_active_in_ha.py
+++ b/plugins/modules/panos_active_in_ha.py
@@ -29,7 +29,7 @@ description:
     - A simple boolean check, verifies if a node is an active (B(true)) or passive (B(false)) node in an HA pair.
     - If node does not belong to an HA pair or the pair is no configured correctly the module will fail.
 author: "Łukasz Pawlęga (@fosix)"
-version_added: '2.19'
+version_added: '2.20.0'
 requirements:
     - pan-python can be obtained from PyPI U(https://pypi.python.org/pypi/pan-python)
     - pandevice can be obtained from PyPI U(https://pypi.python.org/pypi/pandevice)

--- a/plugins/modules/panos_active_in_ha.py
+++ b/plugins/modules/panos_active_in_ha.py
@@ -53,6 +53,13 @@ options:
               node's current state in an HA pair. Can be useful when working with partially upgraded nodes. Use with caution.
         type: bool
         default: false
+    ignore_non_functional:
+        description:
+            - Use with caution, when set to `True` will ignore if device
+            state is `non-functional` on one of the nodes. Helpful when verifying a state of a partially upgraded HA pair with
+            vmseries plugin version mismatch.
+        type: bool
+        default: false
 # """
 
 EXAMPLES = """

--- a/plugins/modules/panos_active_in_ha.py
+++ b/plugins/modules/panos_active_in_ha.py
@@ -55,9 +55,8 @@ options:
         default: false
     ignore_non_functional:
         description:
-            - Use with caution, when set to `True` will ignore if device
-            state is `non-functional` on one of the nodes. Helpful when verifying a state of a partially upgraded HA pair with
-            vmseries plugin version mismatch.
+            - Use with caution, when set to `True` will ignore if device state is `non-functional` on one of the nodes. Helpful
+              when verifying a state of a partially upgraded HA pair with vmseries plugin version mismatch.
         type: bool
         default: false
 # """
@@ -119,7 +118,7 @@ def main():
         argument_spec=dict(
             force_fail=dict(type="bool", default=False),
             skip_config_sync=dict(type="bool", default=False),
-            ignore_non_functional=dict(type="bool", default=False)
+            ignore_non_functional=dict(type="bool", default=False),
         ),
         panorama_error="This is a firewall only module",
     )
@@ -132,7 +131,7 @@ def main():
 
     is_active = CheckFirewall(firewall).check_is_ha_active(
         skip_config_sync=module.params["skip_config_sync"],
-        ignore_non_functional=module.params['ignore_non_functional']
+        ignore_non_functional=module.params['ignore_non_functional'],
     )
 
     if module.params["force_fail"]:

--- a/plugins/modules/panos_active_in_ha.py
+++ b/plugins/modules/panos_active_in_ha.py
@@ -112,6 +112,7 @@ def main():
         argument_spec=dict(
             force_fail=dict(type="bool", default=False),
             skip_config_sync=dict(type="bool", default=False),
+            ignore_non_functional=dict(type="bool", default=False)
         ),
         panorama_error="This is a firewall only module",
     )
@@ -123,7 +124,8 @@ def main():
     firewall = FirewallProxy(firewall=helper.get_pandevice_parent(module))
 
     is_active = CheckFirewall(firewall).check_is_ha_active(
-        skip_config_sync=module.params["skip_config_sync"]
+        skip_config_sync=module.params["skip_config_sync"],
+        ignore_non_functional=module.params['ignore_non_functional']
     )
 
     if module.params["force_fail"]:

--- a/plugins/modules/panos_active_in_ha.py
+++ b/plugins/modules/panos_active_in_ha.py
@@ -131,7 +131,7 @@ def main():
 
     is_active = CheckFirewall(firewall).check_is_ha_active(
         skip_config_sync=module.params["skip_config_sync"],
-        ignore_non_functional=module.params['ignore_non_functional'],
+        ignore_non_functional=module.params["ignore_non_functional"],
     )
 
     if module.params["force_fail"]:

--- a/plugins/modules/panos_active_in_ha.py
+++ b/plugins/modules/panos_active_in_ha.py
@@ -29,7 +29,7 @@ description:
     - A simple boolean check, verifies if a node is an active (B(true)) or passive (B(false)) node in an HA pair.
     - If node does not belong to an HA pair or the pair is no configured correctly the module will fail.
 author: "Łukasz Pawlęga (@fosix)"
-version_added: '2.20'
+version_added: '2.19'
 requirements:
     - pan-python can be obtained from PyPI U(https://pypi.python.org/pypi/pan-python)
     - pandevice can be obtained from PyPI U(https://pypi.python.org/pypi/pandevice)

--- a/plugins/modules/panos_active_in_ha.py
+++ b/plugins/modules/panos_active_in_ha.py
@@ -29,7 +29,7 @@ description:
     - A simple boolean check, verifies if a node is an active (B(true)) or passive (B(false)) node in an HA pair.
     - If node does not belong to an HA pair or the pair is no configured correctly the module will fail.
 author: "Łukasz Pawlęga (@fosix)"
-version_added: '2.20.0'
+version_added: '2.18.0'
 requirements:
     - pan-python can be obtained from PyPI U(https://pypi.python.org/pypi/pan-python)
     - pandevice can be obtained from PyPI U(https://pypi.python.org/pypi/pandevice)

--- a/plugins/modules/panos_active_in_ha.py
+++ b/plugins/modules/panos_active_in_ha.py
@@ -29,7 +29,7 @@ description:
     - A simple boolean check, verifies if a node is an active (B(true)) or passive (B(false)) node in an HA pair.
     - If node does not belong to an HA pair or the pair is no configured correctly the module will fail.
 author: "Łukasz Pawlęga (@fosix)"
-version_added: '2.18.0'
+version_added: '2.19.2'
 requirements:
     - pan-python can be obtained from PyPI U(https://pypi.python.org/pypi/pan-python)
     - pandevice can be obtained from PyPI U(https://pypi.python.org/pypi/pandevice)

--- a/plugins/modules/panos_active_in_ha.py
+++ b/plugins/modules/panos_active_in_ha.py
@@ -29,7 +29,7 @@ description:
     - A simple boolean check, verifies if a node is an active (B(true)) or passive (B(false)) node in an HA pair.
     - If node does not belong to an HA pair or the pair is no configured correctly the module will fail.
 author: "Łukasz Pawlęga (@fosix)"
-version_added: '2.19.2'
+version_added: '2.20'
 requirements:
     - pan-python can be obtained from PyPI U(https://pypi.python.org/pypi/pan-python)
     - pandevice can be obtained from PyPI U(https://pypi.python.org/pypi/pandevice)


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
In customer projects we tended to use local version of `panos_active_in_ha` library and we couldn't switch to the remote module in the collection because in the playbooks we were using `ignore_non_functional` option. This PR adds it.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#559 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested the module as a local copy in a playbook.

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
