### PR TITLE
feat: Add additional error handling to some upgrade assurance modules

### DIFF
--- a/plugins/modules/panos_readiness_checks.py
+++ b/plugins/modules/panos_readiness_checks.py
@@ -148,6 +148,7 @@ MIN_PUA_VER = (0, 3, 0)
 
 try:
     from panos_upgrade_assurance.check_firewall import CheckFirewall
+    from panos_upgrade_assurance.exceptions import UpdateServerConnectivityException
     from panos_upgrade_assurance.firewall_proxy import FirewallProxy
 except ImportError:
     pass

--- a/plugins/modules/panos_snapshot_report.py
+++ b/plugins/modules/panos_snapshot_report.py
@@ -198,10 +198,13 @@ def main():
             )
         )
 
-    results = SnapshotCompare(
-        left_snapshot=module.params["left_snapshot"],
-        right_snapshot=module.params["right_snapshot"],
-    ).compare_snapshots(reports=module.params["reports"])
+    try:
+        results = SnapshotCompare(
+            left_snapshot=module.params["left_snapshot"],
+            right_snapshot=module.params["right_snapshot"],
+        ).compare_snapshots(reports=module.params["reports"])
+    except SnapshotSchemeMismatchException as exc:
+        module.fail_json(msg=getattr(exc, "message", repr(exc)))
 
     module.exit_json(changed=False, response=results)
 

--- a/plugins/modules/panos_snapshot_report.py
+++ b/plugins/modules/panos_snapshot_report.py
@@ -166,6 +166,7 @@ PUA_AVAILABLE = True
 try:
     import panos_upgrade_assurance
     from panos_upgrade_assurance.snapshot_compare import SnapshotCompare
+    from panos_upgrade_assurance.exceptions import SnapshotSchemeMismatchException
 except ImportError:
     PUA_AVAILABLE = False
     pass


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
In customer projects we were using local copies of the following modules:
* `panos_readiness_checks.py`
* `panos_snapshot_report.py`

They had some additional Try Except blocks that were not present in public modules. This PR aims to introduce them.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#559 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
These changes were introduced in local libraries used earlier in Upgrade Automation playbooks.

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
