### PR TITLE
fix required ansible-core version

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -20,7 +20,7 @@ Installation
 
 This collection has the following environment requirements:
 
-* Python 3.8 or higher
+* Python 3.9 or higher
 * ansible-core 2.15 or higher
 
 Install the collection using `ansible-galaxy`:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -21,7 +21,7 @@ Installation
 This collection has the following environment requirements:
 
 * Python 3.8 or higher
-* ansible-core 2.14 or higher
+* ansible-core 2.15 or higher
 
 Install the collection using `ansible-galaxy`:
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -21,7 +21,7 @@ Installation
 This collection has the following environment requirements:
 
 * Python 3.8 or higher
-* Ansible 2.9 or higher
+* ansible-core 2.14 or higher
 
 Install the collection using `ansible-galaxy`:
 


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

Fixed the version in the [Installation Guide](https://paloaltonetworks.github.io/pan-os-ansible/index.html#installation) due to Ansible version information below.

- >Ansible versions before 2.14 are not supported.
  - in README,md
- > requires_ansible: '>=2.14.0'
  - in meta/runtime.yml


## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Due to confusion between different versions of  Installation Guide and meta/runtime.yml

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Document only.


## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)
## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
