### PR TITLE
fix: requirements.txt update python version and remove hashes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,4 +60,4 @@ new-sanity:		## Sanity tests for Ansible v2.11 and above
 
 .PHONY: reqs
 reqs:       ## Recreate the requirements.txt file
-	poetry export -f requirements.txt --output requirements.txt
+	poetry export -f requirements.txt --output requirements.txt --only=main --without-hashes

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,4 @@
-pan-os-python==1.8.0 ; python_version >= "3.8" and python_version < "4.0" \
-    --hash=sha256:843972122ef4c5bfd17354070e3ada1285e243325f5e7cf7fd969150048becd4 \
-    --hash=sha256:da9153fe4a961a43d36016851ab06df45a37ea8612ed36b3b5b528f8394f34f5
-pan-python==0.17.0 ; python_version >= "3.8" and python_version < "4.0" \
-    --hash=sha256:9c074ea2f69a63996a6fefe8935d60dca61660e14715ac19d257ea9b1c41c6e2 \
-    --hash=sha256:f4674e40763c46d5933244b3059a57884e4e28205ef6d0f9ce2dc2013e3db010
-xmltodict==0.12.0 ; python_version >= "3.8" and python_version < "4.0" \
-    --hash=sha256:50d8c638ed7ecb88d90561beedbf720c9b4e851a9fa6c47ebd64e99d166d8a21 \
-    --hash=sha256:8bbcb45cc982f48b2ca8fe7e7827c5d792f217ecf1792626f808bf41c3b86051
-panos-upgrade-assurance==0.3.0 ; python_version >= "3.8" and python_version < "4.0" \
-    --hash=sha256:0e5bb1a1f5bf317086fe118fb80f5d03c1aa1426c8ecdcda657983f392accc63 \
-    --hash=sha256:88bfc470f9bfa09ed22c919f8328782868c649d44e97a06c8d29c32e0211c257
+pan-os-python==1.8.0 ; python_version >= "3.9" and python_version < "4.0"
+pan-python==0.17.0 ; python_version >= "3.9" and python_version < "4.0"
+xmltodict==0.12.0 ; python_version >= "3.9" and python_version < "4.0"
+panos-upgrade-assurance==0.3.0 ; python_version >= "3.9" and python_version < "4.0"


### PR DESCRIPTION
## Description

`requirements.txt` file with hashes causing issues for generating Ansible Execution Environment image when combined with other collections. PR removes hashes from the `requirements.txt` file. 
`make reqs` command in Makefile is also updated to exclude hashes (this command is not being used in the CI yet)  

## How Has This Been Tested?

Tested installing locally on a virtualenv.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
