### PR TITLE
fix!: gathered_filter to process regex correctly

### DIFF
--- a/docs/source/gatheredfilter.rst
+++ b/docs/source/gatheredfilter.rst
@@ -125,6 +125,31 @@ These all do the same thing, listed from fastest to slowest.
     gathered_filter: 'name matches-regex .*?'
 
 
+Example - Matching a Regex
+--------------------------
+
+It is possible to write regex in the following formats;
+
+* Standard regex in single quotation marks(`'`)
+* Escaped backslash in double quotation marks(`"`)
+* Using folded block scalar followed by a dash (`>-`) without any quotation marks
+
+See examples below which correspond to the same regex:
+
+.. code-block:: yaml
+
+    gathered_filter: 'name matches-regex \sPAN\s'
+
+.. code-block:: yaml
+
+    gathered_filter: "name matches-regex \\sPAN\\s"
+
+.. code-block:: yaml
+
+    gathered_filter: >-
+      name matches-regex \sPAN\s
+
+
 Example - Matching a Suffix
 ---------------------------
 

--- a/plugins/module_utils/panos.py
+++ b/plugins/module_utils/panos.py
@@ -1207,8 +1207,8 @@ class ConnectionHelper(object):
         """
         lex = shlex.shlex(logic, posix=True)
         lex.whitespace_split = True
-        lex.commenters = ''
-        lex.escape = ''
+        lex.commenters = ""
+        lex.escape = ""
 
         return list(lex)
 

--- a/plugins/module_utils/panos.py
+++ b/plugins/module_utils/panos.py
@@ -1200,6 +1200,18 @@ class ConnectionHelper(object):
 
         return default_value
 
+    def _shlex_split(self, logic):
+        """Split string using shlex.split without escape char
+
+        Escape char '\' is removed from shlex class to correctly process regex.
+        """
+        lex = shlex.shlex(logic, posix=True)
+        lex.whitespace_split = True
+        lex.commenters = ''
+        lex.escape = ''
+
+        return list(lex)
+
     def matches_gathered_filter(self, item, logic):
         """Returns True if the item and its contents matches the logic given.
 
@@ -1223,7 +1235,7 @@ class ConnectionHelper(object):
         evaler = []
 
         pdepth = 0
-        logic_tokens = shlex.split(logic)
+        logic_tokens = self._shlex_split(logic)
         token_iter = iter(logic_tokens)
         while True:
             end_parens = 0


### PR DESCRIPTION
## Description

Regex expressions in `gathered` state `gathered_filter` required extra escape chars which wasn't a valid regex in deed. 
This PR allows to write valid regex expression in the `gathered_filter`, the previous syntax is not valid anymore hence this is introducing a breaking change.

`shlex.split()` was used to split logic expressions in the `gathered_filter`, which also escaped(removed) backslash `\` chars from the expression and led to a non-working regex. We have implemented our split method using shlex but removing backslash(`\`) escape char from shlex instance to avoid escaping and properly processing regex expressions.

## Motivation and Context

Fixes #579 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on vm firewalls with examples in the issue.

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
