### PR TITLE
fix(panos_static_route): invalid nexthop for none value

### DIFF
--- a/plugins/modules/panos_static_route.py
+++ b/plugins/modules/panos_static_route.py
@@ -157,6 +157,23 @@ from ansible_collections.paloaltonetworks.panos.plugins.module_utils.panos impor
 
 class Helper(ConnectionHelper):
     def spec_handling(self, spec, module):
+        if module.params["state"] == "present" and spec["nexthop_type"] is None:
+            # need this because we dont have the default assignment in sdk-params and
+            # `None` value params are being removed in ParamPath.element method (called via VersionedPanObject.element)
+            spec["nexthop_type"] = "ip-address"
+
+        # default to ip-address when nexthop is set in merged state
+        # we dont know if object exists or not in merged state, and we dont set default values in module invocation
+        # in order to avoid unintended updates to non-provided params, but if nexthop is given, type must be ip-address
+        if module.params["state"] == "merged" and spec["nexthop_type"] is None and spec["nexthop"] is not None:
+            spec["nexthop_type"] = "ip-address"
+
+        # NOTE merged state have a lot of API issues for updating nexthop we will let the API return it..
+        # from None to IP address - "Failed update nexthop_type: Edit breaks config validity"
+        # from IP address to next-vr - "Failed update nexthop_type: Edit breaks config validity"
+
+        # applies for updating existing routes from IP/next-vr/discard to none
+        # however it works for new objects, we ignore this as this is the existing implementation
         if module.params["state"] == "merged" and spec["nexthop_type"] == "none":
             msg = [
                 "Nexthop cannot be set to None with state='merged'.",
@@ -164,8 +181,6 @@ class Helper(ConnectionHelper):
             ]
             module.fail_json(msg=" ".join(msg))
 
-        if spec["nexthop_type"] == "none":
-            spec["nexthop_type"] = None
 
 
 def main():
@@ -182,7 +197,6 @@ def main():
             name=dict(required=True),
             destination=dict(),
             nexthop_type=dict(
-                default="ip-address",
                 choices=["ip-address", "discard", "none", "next-vr"],
             ),
             nexthop=dict(),
@@ -192,6 +206,9 @@ def main():
             enable_path_monitor=dict(type="bool"),
             failure_condition=dict(choices=["any", "all"]),
             preemptive_hold_time=dict(type="int"),
+        ),
+        default_values=dict(
+            nexthop_type="ip-address",
         ),
     )
 


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
This PR fixes issue with `"none"` value for `nexthop_type` in `panos_static_route`. 

This change also requires pan-os-python to accept 'none' value for the nexthop type, proposed on the following PR:
https://github.com/PaloAltoNetworks/pan-os-python/pull/578

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
With the recent change in pan-os-ansible, it fetches default values from pan-os-python sdk while creating or updating objects with None value params. In the existing implementation "none" string value was converted to `None` in the module and fetching default value from pan-os-python sdk (which is 'ip-address') for this lead to a invalid config. 
With this change "none" string value is passed as-is to the pan-os-python and it is also proposed to accept "none" value for the nexthop type in the linked PR.

Fixes #584 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested live on VMSeries firewalls and Panorama.

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
