### PR TITLE
fix: object_handling method for overriding defaults

### DIFF
--- a/plugins/modules/panos_static_route.py
+++ b/plugins/modules/panos_static_route.py
@@ -52,14 +52,13 @@ options:
         type: str
     nexthop_type:
         description:
-            - Type of next hop.
+            - Type of next hop. Defaults to I("ip-address").
         type: str
         choices:
             - ip-address
             - discard
             - none
             - next-vr
-        default: 'ip-address'
     nexthop:
         description:
             - Next hop IP address.  Required if I(state=present).
@@ -165,7 +164,11 @@ class Helper(ConnectionHelper):
         # default to ip-address when nexthop is set in merged state
         # we dont know if object exists or not in merged state, and we dont set default values in module invocation
         # in order to avoid unintended updates to non-provided params, but if nexthop is given, type must be ip-address
-        if module.params["state"] == "merged" and spec["nexthop_type"] is None and spec["nexthop"] is not None:
+        if (
+            module.params["state"] == "merged"
+            and spec["nexthop_type"] is None
+            and spec["nexthop"] is not None
+        ):
             spec["nexthop_type"] = "ip-address"
 
         # NOTE merged state have a lot of API issues for updating nexthop we will let the API return it..
@@ -181,6 +184,10 @@ class Helper(ConnectionHelper):
             ]
             module.fail_json(msg=" ".join(msg))
 
+    def object_handling(self, obj, module):
+        super().object_handling(obj, module)
+        if module.params.get("nexthop_type") == "none":
+            setattr(obj, "nexthop_type", None)
 
 
 def main():

--- a/plugins/modules/panos_static_route.py
+++ b/plugins/modules/panos_static_route.py
@@ -157,6 +157,23 @@ from ansible_collections.paloaltonetworks.panos.plugins.module_utils.panos impor
 
 class Helper(ConnectionHelper):
     def spec_handling(self, spec, module):
+        if module.params["state"] == "present" and spec["nexthop_type"] is None:
+            # need this because we dont have the default assignment in sdk-params and
+            # `None` value params are being removed in ParamPath.element method (called via VersionedPanObject.element)
+            spec["nexthop_type"] = "ip-address"
+
+        # default to ip-address when nexthop is set in merged state
+        # we dont know if object exists or not in merged state, and we dont set default values in module invocation
+        # in order to avoid unintended updates to non-provided params, but if nexthop is given, type must be ip-address
+        if module.params["state"] == "merged" and spec["nexthop_type"] is None and spec["nexthop"] is not None:
+            spec["nexthop_type"] = "ip-address"
+
+        # NOTE merged state have a lot of API issues for updating nexthop we will let the API return it..
+        # from None to IP address - "Failed update nexthop_type: Edit breaks config validity"
+        # from IP address to next-vr - "Failed update nexthop_type: Edit breaks config validity"
+
+        # applies for updating existing routes from IP/next-vr/discard to none
+        # however it works for new objects, we ignore this as this is the existing implementation
         if module.params["state"] == "merged" and spec["nexthop_type"] == "none":
             msg = [
                 "Nexthop cannot be set to None with state='merged'.",
@@ -164,8 +181,6 @@ class Helper(ConnectionHelper):
             ]
             module.fail_json(msg=" ".join(msg))
 
-        if spec["nexthop_type"] == "none":
-            spec["nexthop_type"] = None
 
 
 def main():
@@ -182,7 +197,6 @@ def main():
             name=dict(required=True),
             destination=dict(),
             nexthop_type=dict(
-                default="ip-address",
                 choices=["ip-address", "discard", "none", "next-vr"],
             ),
             nexthop=dict(),
@@ -192,6 +206,9 @@ def main():
             enable_path_monitor=dict(type="bool"),
             failure_condition=dict(choices=["any", "all"]),
             preemptive_hold_time=dict(type="int"),
+        ),
+        default_values=dict(
+            nexthop_type="ip-address",
         ),
     )
 

--- a/plugins/modules/panos_template.py
+++ b/plugins/modules/panos_template.py
@@ -105,6 +105,14 @@ class Helper(ConnectionHelper):
         vsys = to_sdk_cls("device", "Vsys")(module.params["default_vsys"])
         obj.add(vsys)
 
+    def object_handling(self, obj, module):
+        super().object_handling(obj, module)
+        # override 'mode' param sdk default to None if it's not set explicitly in invocation.
+        # SDK has `mode` attribute set to "normal" by default, but there is no xpath for this
+        # resulting in xpath schema error if default is used.
+        if module.params.get("mode") is None:
+            setattr(obj, "mode", None)
+
 
 def main():
     helper = get_connection(


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
This is an alternative approach for mitigating issues on passing `None` value to sdk for params which have default values in order to remove an xpath.

#587 PR and relevant pan-os-python changes would not be needed if we prefer this approach.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We are using default values for `None` provided params for newly created/replaced objects which can cause issue when SDK requires an actual `None` type input to remove an xpath. 

For example pan-os-python does not accept `'none'` string value for the nexthop type in StaticRoute but it requires nexthop type to be `None` type in order to be removed (in order words set to `"None"` in GUI), although it has a default value of `'ip-address'`. Normally we expect to use default values from SDK when the param is `None` type but this kind of cases breaks this approach.

With the proposed `object_handling()` method, it is possible to override values after defaults are assigned so we can mitigate this kind of issues.

Also fixes #584 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested with manually written ansible playbooks.

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
