### PR TITLE
Adding more link_speed options

### DIFF
--- a/.github/workflows/ee.yml
+++ b/.github/workflows/ee.yml
@@ -49,17 +49,17 @@ jobs:
         # outputs tag name as v1.2.3 and version as 1.2.3
         run: |
           if [[ "${{ github.event_name }}" == "push" &&
-                "${{ inputs.release }}" == "true" ]]; then
-              if [[ "${{ inputs.release_tag }}" != "v"* ]]; then
-                  echo "release_tag (${{ inputs.release_tag }}) must be provided when workflow_call called with release."
+                "${RELEASE}" == "true" ]]; then
+              if [[ "${RELEASE_TAG}" != "v"* ]]; then
+                  echo "release_tag (${RELEASE_TAG}) must be provided when workflow_call called with release."
                   exit 1
               fi
-              TAG_VERSION=$(echo "${{inputs.release_tag}}" | sed 's#v##')
-              echo "name=${{inputs.release_tag}}" >> $GITHUB_OUTPUT
+              TAG_VERSION=$(echo "${RELEASE_TAG}" | sed 's#v##')
+              echo "name=${RELEASE_TAG}" >> $GITHUB_OUTPUT
               echo "version=$TAG_VERSION" >> $GITHUB_OUTPUT
-              echo "Ansible EE will be prepared for release ${{ inputs.release_tag }}"
+              echo "Ansible EE will be prepared for release ${RELEASE_TAG}"
           elif [[ "${{ github.event_name }}" == "workflow_dispatch" &&
-                "${{ inputs.release }}" == "true" ]]; then
+                "${RELEASE}" == "true" ]]; then
               if [[ "${GITHUB_REF}" != "refs/tags/v"* ]]; then
                   echo "workflow_dispatch must be run on a release tag when release is selected - run on ${GITHUB_REF}"
                   exit 1
@@ -74,6 +74,8 @@ jobs:
           fi
         env:
           GITHUB_REF: ${{ github.ref }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+          RELEASE: ${{ inputs.release }}
 
   build_awx:
     name: AWX Ansible EE

--- a/.github/workflows/ee.yml
+++ b/.github/workflows/ee.yml
@@ -205,6 +205,7 @@ jobs:
             - name: awx.awx
             - community.general
             - name: ansible.posix
+            - name: ansible.utils
           EOF
           echo "::group::requirements.yml"
           cat requirements.yml
@@ -226,6 +227,7 @@ jobs:
             - name: awx.awx
             - community.general
             - name: ansible.posix
+            - name: ansible.utils
           EOF
           echo "::group::requirements.yml"
           cat requirements.yml
@@ -382,6 +384,7 @@ jobs:
               type: file
             - name: community.general
             - name: ansible.posix
+            - name: ansible.utils
           EOF
           echo "::group::requirements.yml"
           cat requirements.yml
@@ -402,6 +405,7 @@ jobs:
               version: ${{needs.prepare.outputs.version}}
             - name: community.general
             - name: ansible.posix
+            - name: ansible.utils
           EOF
           echo "::group::requirements.yml"
           cat requirements.yml

--- a/plugins/modules/panos_interface.py
+++ b/plugins/modules/panos_interface.py
@@ -109,6 +109,10 @@ options:
             - "10"
             - "100"
             - "1000"
+            - "10000"
+            - "25000"
+            - "40000"
+            - "100000"
     link_duplex:
         description:
             - Link duplex.
@@ -290,7 +294,7 @@ def main():
             lldp_enabled=dict(),
             lldp_profile=dict(),
             netflow_profile_l2=dict(),
-            link_speed=dict(choices=["auto", "10", "100", "1000"]),
+            link_speed=dict(choices=["auto", "10", "100", "1000", "10000", "25000", "40000", "100000"]),
             link_duplex=dict(choices=["auto", "full", "half"]),
             link_state=dict(choices=["auto", "up", "down"]),
             aggregate_group=dict(),


### PR DESCRIPTION
## Description

I'm adding more options for the link_speed parameter to the panos_interface module as there are many more valid link speeds than already in the module.

## Motivation and Context

I've made the PR since I need this change in order to be able to set the link speed of some of the interfaces on my PA-3410 manually when automatic detection of link speed doesn't work. I can set it in the GUI, but I need to also be able to set it using ansible since I use ansible to automate the configuration.

## How Has This Been Tested?

This has been tested by setting link_speed to 25000 using a PA-3410 as target device. It has exactly the same effect as setting 25000 as the link speed using the GUI. I did no other tests but figured I'll add a few more link speed options anyway since other people might find 10G/40G/100G link speeds useful.

I haven't looked overly deep into the code, but I reckon this shouldn't impact anything else meaningfully.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

I'm not sure if there's any documentation external to the file, I tried looking for it, but didn't find anything. I don't know whether this affects tests and don't know where I can see whether or not the tests passes but seeing how small the change is I reckon there's not much testing to be done here.

I skimmed through the contributing document, but figured that was a whole bunch of unnecessary work for a change this small. Might seem arrogant but hard pass on that for this change.

- [ ] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
