### PR TITLE
feat(panos_state_snapshot): allow dict config element for snapshots

### DIFF
--- a/extensions/eda/plugins/event_source/logs.py
+++ b/extensions/eda/plugins/event_source/logs.py
@@ -33,7 +33,7 @@ Example:
 
 """
 
-# ruff: noqa: UP001, UP010, FA102
+# ruff: noqa: UP001, UP010
 from __future__ import absolute_import, division, print_function
 
 # pylint: disable-next=invalid-name

--- a/plugins/modules/panos_state_snapshot.py
+++ b/plugins/modules/panos_state_snapshot.py
@@ -47,9 +47,13 @@ options:
         description:
             - A list of Firewall state areas that we should take a snapshot of. For the details on currently supported list please refer to
               L(package documentation, https://pan.dev/panos/docs/panos-upgrade-assurance/configuration-details/#state-snapshots).
+            - In most of the cases it is enough to specify a snapshot name to run it with default settings.
+              In this case the list element is of type B(str). If additional configuration is required the element is a single element B(dict),
+              where key is the state snapshot name and value contains the snapshot's configuration. For information which snapshot requires additional
+              configuration please refer to L(package documentation, https://pan.dev/panos/docs/panos-upgrade-assurance/configuration-details/#state-snapshots).
             - To capture the actual snapshot data use a register.
         type: list
-        elements: str
+        elements: raw
         default: ["all"]
 """
 

--- a/plugins/modules/panos_state_snapshot.py
+++ b/plugins/modules/panos_state_snapshot.py
@@ -133,7 +133,7 @@ def main():
         with_classic_provider_spec=True,
         min_panos_upgrade_assurance_version=MIN_PUA_VER,
         argument_spec=dict(
-            state_areas=dict(type="list", default=["all"], elements="str")
+            state_areas=dict(type="list", default=["all"], elements="raw")
         ),
         panorama_error="This is a firewall only module",
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ pan-os-python = ">=1.8,<2.0"
 xmltodict = ">=0.12.0,<0.15.0"
 aiohttp = ">=3.8.4,<4.0"
 dpath = ">=2.1.5,<3.0"
-panos-upgrade-assurance = ">=1.0,<2.0"
+panos-upgrade-assurance = ">=1.4,<2.0"
 
 [tool.poetry.dev-dependencies]
 black = ">=22.3.0"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 aiohttp>=3.8.4,<4.0 ; python_version >= "3.10" and python_version < "4.0"
 dpath>=2.1.5,<3.0 ; python_version >= "3.10" and python_version < "4.0"
 pan-os-python>=1.8,<2.0 ; python_version >= "3.10" and python_version < "4.0"
-panos-upgrade-assurance>=1.0,<2.0 ; python_version >= "3.10" and python_version < "4.0"
+panos-upgrade-assurance>=1.4,<2.0 ; python_version >= "3.10" and python_version < "4.0"
 xmltodict>=0.12.0,<0.15.0 ; python_version >= "3.10" and python_version < "4.0"


### PR DESCRIPTION

## Description

<!--- Describe your changes in detail -->
panos-upgrade-assurance 1.4.0 allows to provide snapshot configs as dict element in addition to str. Just like readiness checks. This change allows dict element to be provided for snapshot config elements passed to `panos_state_snapshot` module. upgrade assurance requirement is also bumped as a result of this.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally with playbook implementation.

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
