### PR TITLE
fix: support panorama for userid ip-tags

### DIFF
--- a/plugins/modules/panos_registered_ip.py
+++ b/plugins/modules/panos_registered_ip.py
@@ -32,7 +32,6 @@ requirements:
     - pandevice can be obtained from PyPI U(https://pypi.python.org/pypi/pandevice)
 notes:
     - Check mode is supported.
-    - Panorama is not supported.
 extends_documentation_fragment:
     - paloaltonetworks.panos.fragments.transitional_provider
     - paloaltonetworks.panos.fragments.state
@@ -117,7 +116,6 @@ def main():
         vsys=True,
         with_classic_provider_spec=True,
         with_state=True,
-        panorama_error="Panorama is not supported for this module.",
         argument_spec=dict(
             ips=dict(type="list", elements="str", required=True),
             tags=dict(type="list", elements="str", required=True),

--- a/plugins/modules/panos_registered_ip_facts.py
+++ b/plugins/modules/panos_registered_ip_facts.py
@@ -30,8 +30,6 @@ version_added: '1.0.0'
 requirements:
     - pan-python can be obtained from PyPI U(https://pypi.python.org/pypi/pan-python)
     - pandevice can be obtained from PyPI U(https://pypi.python.org/pypi/pandevice)
-notes:
-    - Panorama is not supported.
 extends_documentation_fragment:
     - paloaltonetworks.panos.fragments.transitional_provider
     - paloaltonetworks.panos.fragments.vsys
@@ -93,7 +91,6 @@ def main():
     helper = get_connection(
         vsys=True,
         with_classic_provider_spec=True,
-        panorama_error="Panorama is not supported for this module.",
         argument_spec=dict(
             tags=dict(type="list", elements="str"),
             ips=dict(type="list", elements="str"),


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
userid API is also available on Panorama, so `panos_registered_ip` and `panos_registered_ip_facts` should work with Panorama.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested manually with ansible playbooks.

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
