### PR TITLE
feat(panos_software): support Skip Software Version Upgrade

### DIFF
--- a/plugins/modules/panos_software.py
+++ b/plugins/modules/panos_software.py
@@ -141,16 +141,6 @@ except ImportError:
     except ImportError:
         pass
 
-# PAN-OS version sequence for Skip Software Version Upgrade supported from 10.1
-# It is recommended to skip at most 2 major/minor release from 10.1 and 3 major/minor release from 11.0
-version_sequence = [
-    PanOSVersion("10.1"),
-    PanOSVersion("10.2"),
-    PanOSVersion("11.0"),
-    PanOSVersion("11.1"),
-    PanOSVersion("11.2"),
-    PanOSVersion("12.1")
-]
 
 def needs_download(device, version):
     device.software.info()
@@ -159,6 +149,17 @@ def needs_download(device, version):
 
 
 def is_valid_sequence(current, target):
+    # PAN-OS version sequence for Skip Software Version Upgrade supported from 10.1
+    # It is recommended to skip at most 2 major/minor release from 10.1 and 3 major/minor release from 11.0
+    version_sequence = [
+        PanOSVersion("10.1"),
+        PanOSVersion("10.2"),
+        PanOSVersion("11.0"),
+        PanOSVersion("11.1"),
+        PanOSVersion("11.2"),
+        PanOSVersion("12.1"),
+    ]
+
     # Patch version change (major and minor versions match)
     if (current.major == target.major) and (current.minor == target.minor):
         return True
@@ -202,18 +203,23 @@ def is_valid_sequence(current, target):
 
             # Downgrade path
             if version_distance < 0:
-                if target < PanOSVersion("10.1.0"):  # downgrades supported to min 10.1 for Skip Software Version
+                if target < PanOSVersion("10.1.0"):
+                    # downgrades supported to min 10.1 for Skip Software Version
                     return False
 
                 # For all versions >= 10.1, allow skipping at most 3 versions in downgrade
                 # (11.2 -> 10.1) or (12.1 -> 10.2)
-                return abs_version_distance <= 4  # Distance of 4 means skipping 3 versions
+                return (
+                    abs_version_distance <= 4
+                )  # Distance of 4 means skipping 3 versions
 
             # Upgrade path
             else:
                 # For all versions >= 10.1, allow skipping at most 3 versions in upgrade
                 # (10.1 -> 11.2) or (10.2 -> 12.1)
-                return abs_version_distance <= 4  # Distance of 4 means skipping 3 versions
+                return (
+                    abs_version_distance <= 4
+                )  # Distance of 4 means skipping 3 versions
 
         except (ValueError, TypeError):  # If there's any issue with version comparisons
             return False

--- a/plugins/modules/panos_software.py
+++ b/plugins/modules/panos_software.py
@@ -141,6 +141,16 @@ except ImportError:
     except ImportError:
         pass
 
+# PAN-OS version sequence for Skip Software Version Upgrade supported from 10.1
+# It is recommended to skip at most 2 major/minor release from 10.1 and 3 major/minor release from 11.0
+version_sequence = [
+    PanOSVersion("10.1"),
+    PanOSVersion("10.2"),
+    PanOSVersion("11.0"),
+    PanOSVersion("11.1"),
+    PanOSVersion("11.2"),
+    PanOSVersion("12.1")
+]
 
 def needs_download(device, version):
     device.software.info()
@@ -169,8 +179,47 @@ def is_valid_sequence(current, target):
     elif current.major - 1 == target.major:
         return True
 
-    else:
-        return False
+    # Skip Software Version Upgrade version logic for >= 10.1
+    elif current >= PanOSVersion("10.1.0"):
+        try:
+            current_index = -1
+            target_index = -1
+
+            # Find the indices of current and target versions in the sequence
+            for i, version in enumerate(version_sequence):
+                if current.major == version.major and current.minor == version.minor:
+                    current_index = i
+                if target.major == version.major and target.minor == version.minor:
+                    target_index = i
+
+            # fail if either version is not in our sequence
+            if current_index == -1 or target_index == -1:
+                return False
+
+            # Calculate version distance based on the sequence
+            version_distance = target_index - current_index
+            abs_version_distance = abs(version_distance)
+
+            # Downgrade path
+            if version_distance < 0:
+                if target < PanOSVersion("10.1.0"):  # downgrades supported to min 10.1 for Skip Software Version
+                    return False
+
+                # For all versions >= 10.1, allow skipping at most 3 versions in downgrade
+                # (11.2 -> 10.1) or (12.1 -> 10.2)
+                return abs_version_distance <= 4  # Distance of 4 means skipping 3 versions
+
+            # Upgrade path
+            else:
+                # For all versions >= 10.1, allow skipping at most 3 versions in upgrade
+                # (10.1 -> 11.2) or (10.2 -> 12.1)
+                return abs_version_distance <= 4  # Distance of 4 means skipping 3 versions
+
+        except (ValueError, TypeError):  # If there's any issue with version comparisons
+            return False
+
+    # if nothing matched so far
+    return False
 
 
 def main():


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Skipping 3 major/minor releases is allowed for both upgrade and downgrade paths for PAN-OS devices supporting Skip Software Version Upgrade feature starting from 10.1 onwards.

Downgrade path is limited to min. 10.1.x release when downgrading from Skip Software Version Upgrade supported PAN-OS devices.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #553 #629 
also supercedes #599 allowing to skip 3 major/minor releases after 10.1.x

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested with local playbook.

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->
- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
