### PR TITLE
Added new modules to allow for the creation of device LDAP server profiles and assign LDAP servers to LDAP profiles.

### DIFF
--- a/.github/workflows/ee.yml
+++ b/.github/workflows/ee.yml
@@ -49,17 +49,17 @@ jobs:
         # outputs tag name as v1.2.3 and version as 1.2.3
         run: |
           if [[ "${{ github.event_name }}" == "push" &&
-                "${{ inputs.release }}" == "true" ]]; then
-              if [[ "${{ inputs.release_tag }}" != "v"* ]]; then
-                  echo "release_tag (${{ inputs.release_tag }}) must be provided when workflow_call called with release."
+                "${RELEASE}" == "true" ]]; then
+              if [[ "${RELEASE_TAG}" != "v"* ]]; then
+                  echo "release_tag (${RELEASE_TAG}) must be provided when workflow_call called with release."
                   exit 1
               fi
-              TAG_VERSION=$(echo "${{inputs.release_tag}}" | sed 's#v##')
-              echo "name=${{inputs.release_tag}}" >> $GITHUB_OUTPUT
+              TAG_VERSION=$(echo "${RELEASE_TAG}" | sed 's#v##')
+              echo "name=${RELEASE_TAG}" >> $GITHUB_OUTPUT
               echo "version=$TAG_VERSION" >> $GITHUB_OUTPUT
-              echo "Ansible EE will be prepared for release ${{ inputs.release_tag }}"
+              echo "Ansible EE will be prepared for release ${RELEASE_TAG}"
           elif [[ "${{ github.event_name }}" == "workflow_dispatch" &&
-                "${{ inputs.release }}" == "true" ]]; then
+                "${RELEASE}" == "true" ]]; then
               if [[ "${GITHUB_REF}" != "refs/tags/v"* ]]; then
                   echo "workflow_dispatch must be run on a release tag when release is selected - run on ${GITHUB_REF}"
                   exit 1
@@ -74,6 +74,8 @@ jobs:
           fi
         env:
           GITHUB_REF: ${{ github.ref }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+          RELEASE: ${{ inputs.release }}
 
   build_awx:
     name: AWX Ansible EE

--- a/.github/workflows/ee.yml
+++ b/.github/workflows/ee.yml
@@ -205,6 +205,7 @@ jobs:
             - name: awx.awx
             - community.general
             - name: ansible.posix
+            - name: ansible.utils
           EOF
           echo "::group::requirements.yml"
           cat requirements.yml
@@ -226,6 +227,7 @@ jobs:
             - name: awx.awx
             - community.general
             - name: ansible.posix
+            - name: ansible.utils
           EOF
           echo "::group::requirements.yml"
           cat requirements.yml
@@ -382,6 +384,7 @@ jobs:
               type: file
             - name: community.general
             - name: ansible.posix
+            - name: ansible.utils
           EOF
           echo "::group::requirements.yml"
           cat requirements.yml
@@ -402,6 +405,7 @@ jobs:
               version: ${{needs.prepare.outputs.version}}
             - name: community.general
             - name: ansible.posix
+            - name: ansible.utils
           EOF
           echo "::group::requirements.yml"
           cat requirements.yml

--- a/plugins/modules/panos_ldap_profile.py
+++ b/plugins/modules/panos_ldap_profile.py
@@ -1,0 +1,149 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+#  Copyright 2019 Palo Alto Networks, Inc
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = """
+---
+module: panos_ldap_profile
+short_description: Manage LDAP server profiles.
+description:
+    - Manages LDAP server profiles.
+author: "Garfield Lee Freeman (@shinmog)"
+version_added: '1.0.0'
+requirements:
+    - pan-python
+    - pandevice >= 0.11.1
+notes:
+    - Panorama is supported.
+    - Check mode is supported.
+extends_documentation_fragment:
+    - paloaltonetworks.panos.fragments.transitional_provider
+    - paloaltonetworks.panos.fragments.network_resource_module_state
+    - paloaltonetworks.panos.fragments.gathered_filter
+    - paloaltonetworks.panos.fragments.vsys_shared
+    - paloaltonetworks.panos.fragments.device_group
+options:
+    name:
+        description:
+            - Name of the LDAP server profile.
+        type: str
+        required: True
+    ldap_type:
+        description:
+            - Ldap profile type.
+        type: str
+        choices:
+            - other
+            - active-directory
+            - e-directory
+            - sun
+        default: other
+    base_dn:
+        description:
+            - Base DN.
+        type: str
+    bind_dn:
+        description:
+            - Bind DN.
+        type: str
+    bind_password:
+        description:
+            - Bind password.
+        type: str
+    bind_timelimit:
+        description:
+            - Bind timeout.
+        type: int
+    timelimit:
+        description:
+            - Search timeout.
+        type: int
+    retry_interval :
+        description:
+            - Retry interval.
+        type: int
+    require_ssl:
+        description:
+            - Require ssl/ttls secured connection.
+        type: bool
+    verify_server_certificate:
+        description:
+            - Verify server certificate for ssl sessions.
+        type: bool
+    disabled:
+        description:
+            - Disabled or not.
+        type: bool
+"""
+
+EXAMPLES = """
+# Create an LDAP profile
+- name: Create LDAP profile
+  paloaltonetworks.panos.panos_ldap_profile:
+    provider: '{{ provider }}'
+    name: 'my-profile'
+"""
+
+RETURN = """
+# Default return values
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.paloaltonetworks.panos.plugins.module_utils.panos import (
+    get_connection,
+)
+
+def main():
+    helper = get_connection(
+        vsys_shared=True,
+        device_group=True,
+        with_network_resource_module_state=True,
+        with_gathered_filter=True,
+        with_classic_provider_spec=True,
+        min_pandevice_version=(0, 11, 1),
+        min_panos_version=(7, 0, 0),
+        sdk_cls=("device", "LdapServerProfile"),
+        sdk_params=dict(
+            name=dict(required=True),
+            ldap_type=dict(choices=["other", "active-directory", "e-directory", "sun"], default="other"),
+            base_dn=dict(sdk_param="base"),
+            bind_dn=dict(),
+            bind_password=dict(),
+            bind_timelimit=dict(type="int"),
+            timelimit=dict(type="int"),
+            retry_interval=dict(type="int"),
+            require_ssl=dict(type="bool", sdk_param="ssl"),
+            verify_server_certificate=dict(type="bool"),
+            disabled=dict(type="bool")
+
+        ),
+    )
+
+    module = AnsibleModule(
+        argument_spec=helper.argument_spec,
+        supports_check_mode=True,
+        required_one_of=helper.required_one_of,
+    )
+
+    helper.process(module)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/panos_ldap_profile.py
+++ b/plugins/modules/panos_ldap_profile.py
@@ -44,7 +44,6 @@ options:
         description:
             - Name of the LDAP server profile.
         type: str
-        required: True
     ldap_type:
         description:
             - Ldap profile type.
@@ -110,6 +109,7 @@ from ansible_collections.paloaltonetworks.panos.plugins.module_utils.panos impor
     get_connection,
 )
 
+
 def main():
     helper = get_connection(
         vsys_shared=True,
@@ -121,11 +121,11 @@ def main():
         min_panos_version=(7, 0, 0),
         sdk_cls=("device", "LdapServerProfile"),
         sdk_params=dict(
-            name=dict(required=True),
+            name=dict(),
             ldap_type=dict(choices=["other", "active-directory", "e-directory", "sun"], default="other"),
             base_dn=dict(sdk_param="base"),
             bind_dn=dict(),
-            bind_password=dict(),
+            bind_password=dict(no_log=True),
             bind_timelimit=dict(type="int"),
             timelimit=dict(type="int"),
             retry_interval=dict(type="int"),

--- a/plugins/modules/panos_ldap_server.py
+++ b/plugins/modules/panos_ldap_server.py
@@ -49,13 +49,11 @@ options:
         description:
             - Name of the LDAP server profile.
         type: str
-        required: True
     ldap_server_address:
         description:
             - IP address or FQDN of ldap server to use.
         type: str
-        required: True
-    port:
+    ldap_port:
         description:
             - Port number
         type: str
@@ -81,6 +79,7 @@ from ansible_collections.paloaltonetworks.panos.plugins.module_utils.panos impor
     get_connection,
 )
 
+
 def main():
     helper = get_connection(
         vsys_shared=True,
@@ -93,8 +92,8 @@ def main():
         parents=(("device", "LdapServerProfile", "ldap_profile"),),
         sdk_cls=("device", "LdapServer"),
         sdk_params=dict(
-            name=dict(required=True),
-            ldap_server_address=dict(required=True, type="str", sdk_param="address"),
+            name=dict(),
+            ldap_server_address=dict(type="str", sdk_param="address"),
             ldap_port=dict(type="str", sdk_param="port"),
         ),
     )

--- a/plugins/modules/panos_ldap_server.py
+++ b/plugins/modules/panos_ldap_server.py
@@ -1,0 +1,112 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+#  Copyright 2019 Palo Alto Networks, Inc
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = """
+---
+module: panos_ldap_server
+short_description: Manage LDAP servers in an LDAP profile.
+description:
+    - Manages LDAP servers in an LDAP server profile.
+author: "Garfield Lee Freeman (@shinmog)"
+version_added: '1.0.0'
+requirements:
+    - pan-python
+    - pandevice >= 0.11.1
+notes:
+    - Panorama is supported.
+    - Check mode is supported.
+extends_documentation_fragment:
+    - paloaltonetworks.panos.fragments.transitional_provider
+    - paloaltonetworks.panos.fragments.vsys_shared
+    - paloaltonetworks.panos.fragments.device_group
+    - paloaltonetworks.panos.fragments.network_resource_module_state
+    - paloaltonetworks.panos.fragments.gathered_filter
+options:
+    ldap_profile:
+        description:
+            - Name of the LDAP server profile.
+        type: str
+        required: True
+    name:
+        description:
+            - Name of the LDAP server profile.
+        type: str
+        required: True
+    ldap_server_address:
+        description:
+            - IP address or FQDN of ldap server to use.
+        type: str
+        required: True
+    port:
+        description:
+            - Port number
+        type: str
+"""
+
+EXAMPLES = """
+# Create an LDAP server and assign to 'my-profile' LDAP Server Profile
+- name: Create LDAP server in an LDAP profile
+  paloaltonetworks.panos.panos_ldap_server:
+    provider: '{{ provider }}'
+    ldap_profile: 'my-profile'
+    name: 'my-ldap-server'
+    ldap_server_address: 'lldap.example.com'
+    port: '637'
+"""
+
+RETURN = """
+# Default return values
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.paloaltonetworks.panos.plugins.module_utils.panos import (
+    get_connection,
+)
+
+def main():
+    helper = get_connection(
+        vsys_shared=True,
+        device_group=True,
+        with_network_resource_module_state=True,
+        with_gathered_filter=True,
+        with_classic_provider_spec=True,
+        min_pandevice_version=(0, 11, 1),
+        min_panos_version=(7, 0, 0),
+        parents=(("device", "LdapServerProfile", "ldap_profile"),),
+        sdk_cls=("device", "LdapServer"),
+        sdk_params=dict(
+            name=dict(required=True),
+            ldap_server_address=dict(required=True, type="str", sdk_param="address"),
+            ldap_port=dict(type="str", sdk_param="port"),
+        ),
+    )
+
+    module = AnsibleModule(
+        argument_spec=helper.argument_spec,
+        supports_check_mode=True,
+        required_one_of=helper.required_one_of,
+    )
+
+    helper.process(module)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Description

Added 2 new modules to allow for the creation of device LDAP server profiles and assign LDAP servers to LDAP profiles.
panos_ldap_server.py
panos_ldap_profile.py

## Motivation and Context

This allows for Ansible based automations to handle password changes for service accounts or any other related environment changes around LDAP servers and profiles. 

## How Has This Been Tested?

This was tested using virtual Palo Devices and an ubuntu VM running ansible with the necessary requirements for execution. 

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
