### PR TITLE
fix(panos_software): use correct base image for 12.1.x train

### DIFF
--- a/plugins/modules/panos_software.py
+++ b/plugins/modules/panos_software.py
@@ -147,6 +147,7 @@ BASE_IMAGE_OVERRIDES = {
     (12, 1): "12.1.2",
 }
 
+
 def needs_download(device, version):
     device.software.info()
 
@@ -312,7 +313,7 @@ def main():
                     "{0}.{1}.0".format(target.major, target.minor),
                 )
                 base = PanOSVersion(_base_str)
-                
+
                 if needs_download(device, base) and not module.check_mode:
                     device.software.download(base, sync_to_peer, sync=True)
                     changed = True

--- a/plugins/modules/panos_software.py
+++ b/plugins/modules/panos_software.py
@@ -141,6 +141,11 @@ except ImportError:
     except ImportError:
         pass
 
+# Base image versions that differ from the default X.Y.0 pattern.
+# Add entries here when a major.minor train uses a non-zero patch as its base image.
+BASE_IMAGE_OVERRIDES = {
+    (12, 1): "12.1.2",
+}
 
 def needs_download(device, version):
     device.software.info()
@@ -301,8 +306,13 @@ def main():
             if download and (
                 (current.major != target.major) or (current.minor != target.minor)
             ):
-                base = PanOSVersion("{0}.{1}.0".format(target.major, target.minor))
 
+                _base_str = BASE_IMAGE_OVERRIDES.get(
+                    (target.major, target.minor),
+                    "{0}.{1}.0".format(target.major, target.minor),
+                )
+                base = PanOSVersion(_base_str)
+                
                 if needs_download(device, base) and not module.check_mode:
                     device.software.download(base, sync_to_peer, sync=True)
                     changed = True


### PR DESCRIPTION
## Summary

Fixes #662

The base image for PAN-OS 12.1.x is `12.1.2`, not `12.1.0`.
The current code always constructs the base image version as `X.Y.0`,
which causes the download to fail for the 12.1 train.

## Changes

- Add `BASE_IMAGE_OVERRIDES` dict to map major.minor versions to their
  correct base image where it differs from `X.Y.0`
- Use the override when determining the base image to download

## Testing

Verified that upgrading from 11.2.10 to 12.1.4 now correctly downloads
`12.1.2` as the base image and completes successfully.

| | Before | After |
|---|---|---|
| 11.2.x → 12.1.4 | Fails (tries to download 12.1.0) | Success (downloads 12.1.2) |
| 10.2.x → 10.2.8 | Success | Success (no change) |