### PR TITLE
fix(apply_position): return True in check_mode when object not present

### DIFF
--- a/plugins/module_utils/panos.py
+++ b/plugins/module_utils/panos.py
@@ -1062,6 +1062,8 @@ class ConnectionHelper(object):
             obj_index = listing.index(uid)
             rule = rules[obj_index]
         except ValueError:
+            if module.check_mode:
+                return True
             module.fail_json(msg="Object {0} isn't present for move".format(uid))
 
         if location == "top":


### PR DESCRIPTION
In check_mode, create() is intentionally skipped so the object does not exist on the device. apply_position() calling fail_json() in this case is incorrect — the object not being present is expected behaviour. Return True (changed) instead so check_mode runs cleanly end-to-end.
## Description

After fixing partial candidate config bug of paloaltonetworks.panos.panos_security_rule, check_mode no longer worked for this module. With this change it is working again.

## Motivation and Context

Needed for successfull check_mode when this fix is applied:
Fixes https://github.com/PaloAltoNetworks/pan-os-ansible/issues/642

## How Has This Been Tested?

Check_mode will for paloaltonetworks.panos.panos_security_rule module will fail without this fix, was tested with playbook run containing both fixes.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)
- Needed for bug fix: https://github.com/PaloAltoNetworks/pan-os-python/pull/621

## Checklist

- [ x] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
- [x ] I have added tests to cover my changes if appropriate.
- [x ] All new and existing tests passed.